### PR TITLE
feature: user entity

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/user/entity/User.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/user/entity/User.java
@@ -1,4 +1,52 @@
 package dnaaaaahtac.wooriforei.domain.user.entity;
 
-public class User {
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Entity
+@Getter
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer userId;
+
+    @Column(length = 100)
+    private String image;
+
+    @Column(length = 50, nullable = false)
+    private String username;
+
+    @Column(length = 50, nullable = false)
+    private String nickname;
+
+    @Column(length = 200, nullable = false)
+    private String userEmail;
+
+    @Column(length = 128, nullable = false)
+    private String password;
+
+    @Transient
+    private String checkPassword;
+
+    @Column(nullable = false)
+    private Boolean isAgreed;
+
+    @Column(nullable = false)
+    private Boolean isAuthenticated;
+
+    @Column(length = 300)
+    private String introduction;
+
+    @Column(length = 4)
+    private String mbti;
+
+    private Date birthday;
+
+    @Column(length = 100)
+    private String nation;
 }


### PR DESCRIPTION
ERD에서 user테이블을 설계할 때는, 테이블 명을 파스칼케이스인 Users로 하였습니다.

그렇지만, 인텔리제이에서

`@Table(name = "Users", schema = "member")`

로 했더니, 바로 경고가 떴어요.

1. 원인: 
* lower_case_table_names 설정 때문 ~~← 억울하게도 설정한 기억이 없습니다~~
* 특히, Window나 macOS에서 작업할 때 이런 현상이 자주 나타남

2. 해결법
* Users로 테이블을 생성해도 실제로는 users로 저장 된다고 함
* 그냥 받아들여..

3. 결론
* @daeundada 님도 테이블명을 소문자로 구성해야할 것 같아요
* erd는 그대로 내두죠!
* 해결 방법이 있다면 알려주세요