### PR TITLE
setting: Spring Security, JWT 등 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // JWT
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/entity/auth.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/entity/auth.java
@@ -1,4 +1,0 @@
-package dnaaaaahtac.wooriforei.domain.auth.entity;
-
-public class auth {
-}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/user/repository/UserRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package dnaaaaahtac.wooriforei.domain.user.repository;
+
+import dnaaaaahtac.wooriforei.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/Jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/Jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,53 @@
+package dnaaaaahtac.wooriforei.global.Jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            String token = jwtUtil.resolveToken(request);
+            if (token != null && jwtUtil.validationToken(token)) {
+                Claims claims = jwtUtil.getUserInfoFromToken(token);
+                String username = claims.getSubject();
+
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            log.error("Security issue: {}", exception.getMessage());
+            throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/Jwt/JwtUtil.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/Jwt/JwtUtil.java
@@ -1,4 +1,93 @@
 package dnaaaaahtac.wooriforei.global.Jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Slf4j
 public class JwtUtil {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public static final String BEARER_PREFIX = "Bearer ";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+
+    public boolean validationToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException exception) {
+            throw new CustomException(ErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (MalformedJwtException | UnsupportedJwtException exception) {
+            throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
+        } catch (IllegalArgumentException exception) {
+            throw new CustomException(ErrorCode.UNSUPPORTED_JWT_TOKEN);
+        }
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+
+    public String createToken(String username) {
+        Date date = new Date();
+        long TOKEN_TIME = 60 * 60 * 1000;
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(username)
+                        .setExpiration(new Date(date.getTime() + TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public String createToken(String username, long validityInMillis) {
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + validityInMillis);
+
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(expiryDate)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/JpaAuditingConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/JpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package dnaaaaahtac.wooriforei.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaAuditingConfig {
-}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/JpaConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/JpaConfig.java
@@ -1,0 +1,22 @@
+package dnaaaaahtac.wooriforei.global.config;
+
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, entityManager);
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/RestTemplateConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/RestTemplateConfig.java
@@ -1,0 +1,22 @@
+package dnaaaaahtac.wooriforei.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+
+        // 외부 API 호출 시 30초가 지나도 응답이 없을 때 강제 종료
+        return restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(30))
+                .setReadTimeout(Duration.ofSeconds(30))
+                .build();
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
@@ -1,0 +1,62 @@
+package dnaaaaahtac.wooriforei.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dnaaaaahtac.wooriforei.global.Jwt.JwtAuthorizationFilter;
+import dnaaaaahtac.wooriforei.global.Jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.reactive.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+    private final UserDetailsService userDetailsService;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter() {
+        return new JwtAuthorizationFilter(jwtUtil, userDetailsService, objectMapper);
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // CSRF 설정
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        // 기본 설정인 Session 방식은 사용하지 않고 JWT 방식을 사용하기 위한 설정
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers(String.valueOf(PathRequest.toStaticResources().atCommonLocations()))
+                        .permitAll()
+                        .requestMatchers("/api/users/**").permitAll()
+                        .requestMatchers("/api/openAPI/**").permitAll()
+                        .anyRequest().authenticated()
+        );
+
+
+        // 필터 처리
+        http.addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -16,9 +16,12 @@ public enum ErrorCode {
     // Scheduler
 
     // User
-    NOT_FOUND_USER_EXCEPTION(404, "해당 유저가 존재하지 않습니다.");
+    NOT_FOUND_USER_EXCEPTION(404, "해당 유저가 존재하지 않습니다."),
 
     // Common
+    INVALID_JWT_TOKEN(401, "유효하지 않은 JWT 토큰입니다."),
+    EXPIRED_JWT_TOKEN(401, "JWT 토큰이 만료되었습니다."),
+    UNSUPPORTED_JWT_TOKEN(401, "지원되지 않는 JWT 토큰입니다.");
 
     private final int statusCode;
 

--- a/src/main/java/dnaaaaahtac/wooriforei/global/security/UserDetailsImpl.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/security/UserDetailsImpl.java
@@ -1,0 +1,54 @@
+package dnaaaaahtac.wooriforei.global.security;
+
+import dnaaaaahtac.wooriforei.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final User user;
+
+    public UserDetailsImpl(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/security/UserDetailsService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/security/UserDetailsService.java
@@ -1,0 +1,23 @@
+package dnaaaaahtac.wooriforei.global.security;
+
+import dnaaaaahtac.wooriforei.domain.user.entity.User;
+import dnaaaaahtac.wooriforei.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+
+        return new UserDetailsImpl(user);
+    }
+}


### PR DESCRIPTION
### Issue: @NonNullApi 관련 경고 해결

#### 문제 상황

`doFilterInternal` 메서드의 매개변수에 대해 `@NonNullApi` 어노테이션을 사용하여 모든 매개변수를 기본적으로 NonNull로 처리하도록 설정했습니다. 그러나, 메서드의 매개변수에 명시적인 Nullness 어노테이션이 없어 다음과 같은 경고가 발생했습니다:

```
경고:(32, 56) 어노테이션이 없는 매개변수가 @NonNullApi 매개변수를 재정의합니다
```

#### 해결 방안

해당 메서드의 매개변수에 `@NonNull` 어노테이션을 추가하여 명시적으로 매개변수가 null이 아님을 지정함으로써 문제를 해결했습니다.

#### 코드 변경

변경 전:

```java
protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
```

변경 후:

```java
import org.springframework.lang.NonNull;
// 필요한 다른 import 문

@Override
protected void doFilterInternal(@NonNull HttpServletRequest request, 
                                @NonNull HttpServletResponse response, 
                                @NonNull FilterChain filterChain) 
                                throws ServletException, IOException {
    // 메서드 구현
}
```

이 변경을 통해 `@NonNullApi` 어노테이션의 기본 규칙에 따르면서도, 명시적으로 매개변수가 null이 아님을 표시할 수 있게 되었습니다. 이로써 관련 경고가 해결되었습니다.
