### PR TITLE
feature: 사용자 일반 로그인

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/controller/AuthController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/controller/AuthController.java
@@ -1,11 +1,16 @@
 package dnaaaaahtac.wooriforei.domain.auth.controller;
 
+import dnaaaaahtac.wooriforei.domain.auth.dto.LoginRequestDTO;
+import dnaaaaahtac.wooriforei.domain.auth.dto.LoginUserResponseDTO;
 import dnaaaaahtac.wooriforei.domain.auth.dto.RegisterAdminRequestDTO;
 import dnaaaaahtac.wooriforei.domain.auth.dto.RegisterUserRequestDTO;
 import dnaaaaahtac.wooriforei.domain.auth.service.AuthService;
+import dnaaaaahtac.wooriforei.global.Jwt.JwtUtil;
 import dnaaaaahtac.wooriforei.global.common.CommonResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,13 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
-    @Autowired
-    private AuthService authService;
-
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder passwordEncoder;
 
     @PostMapping("/signup")
     public ResponseEntity<CommonResponse<Void>> registerUser(
@@ -43,4 +47,17 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("관리자 회원가입 성공", null));
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponse<LoginUserResponseDTO>> login(
+            @RequestBody @Valid LoginRequestDTO requestDTO, HttpServletResponse response) {
+
+        LoginUserResponseDTO loginUserResponseDTO = authService.loginUser(requestDTO);
+        String jwtToken = jwtUtil.createToken(loginUserResponseDTO.getUsername());
+        response.setHeader(HttpHeaders.AUTHORIZATION, jwtToken);
+
+        return ResponseEntity.ok()
+                .body(CommonResponse.of("사용자 로그인 성공", loginUserResponseDTO));
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/LoginRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/LoginRequestDTO.java
@@ -1,0 +1,18 @@
+package dnaaaaahtac.wooriforei.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDTO {
+
+    private String email;
+    private String password;
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/LoginUserResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/LoginUserResponseDTO.java
@@ -1,0 +1,18 @@
+package dnaaaaahtac.wooriforei.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginUserResponseDTO {
+
+    private Long userId;
+    private String username;
+    private String nickname;
+    private String email;
+    private String introduction;
+    private String mbti;
+    private String birthday;
+    private String nation;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     NICKNAME_ALREADY_EXISTS(400, "이미 사용중인 닉네임입니다."),
     PASSWORD_CONFIRMATION_FAILED(400, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     AGREEMENT_NOT_ACCEPTED(400, "약관에 동의하지 않았습니다."),
+    INVALID_PASSWORD(401, "이메일 또는 비밀번호가 유효하지 않습니다."),
 
     // Board
 


### PR DESCRIPTION
사용자 일반 로그인 성공 후 JWT 액세스 토큰을 생성하고 이를 HTTP 응답 헤더에 첨부하는 기능을 포함하였습니다.

### 주요 변경 사항:

* 사용자 인증 정보를 검증하고 JWT 토큰을 생성하는 AuthService 내 login 메소드를 구현하였습니다.
* 응답 헤더에 생성된 액세스 토큰을 포함시키도록 AuthController를 업데이트하였습니다.
* 사용자명을 기반으로 토큰을 생성하는 JwtUtil의 유틸리티 메소드를 추가하였습니다.
* 클라이언트 측에 필요한 모든 사용자 정보가 LoginUserResponseDTO에 포함되도록 하였습니다.

### 테스트 결과:

* JWT 토큰이 정확히 생성되어 응답 헤더에 포함되는 것을 확인하였습니다.
* 토큰의 유효성을 검사하고 올바른 클레임이 포함되어 있는지 확인하였습니다.

### 추가 사항:
* 오류 코드는 INVALID_PASSWORD 하나만 추가하였는데, 이는 보안의 효율성을 위함입니다.

변경 사항을 검토하시고 피드백 부탁드립니다.