### PR TITLE
feature: 관리자 로그인

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/admin/entity/Admin.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/admin/entity/Admin.java
@@ -12,6 +12,9 @@ public class Admin {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long adminId;
 
+    @Column(length = 100, nullable = false)
+    private String adminName;
+
     @Column(length = 200, nullable = false)
     private String adminEmail;
 
@@ -28,7 +31,7 @@ public class Admin {
     private boolean isAuthenticated = false;
 
     @Column(nullable = false)
-    private String phone;
+    private String phoneNumber;
 
     public void setAdminId(Long adminId) {
         this.adminId = adminId;
@@ -46,8 +49,8 @@ public class Admin {
         this.checkPassword = checkPassword;
     }
 
-    public void setPhone(String phone) {
-        this.phone = phone;
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
     }
 
     public void setAgreed(boolean agreed) {
@@ -56,5 +59,9 @@ public class Admin {
 
     public void setAuthenticated(boolean authenticated) {
         isAuthenticated = authenticated;
+    }
+
+    public void setAdminName(String adminName) {
+        this.adminName = adminName;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/controller/AuthController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/controller/AuthController.java
@@ -1,9 +1,6 @@
 package dnaaaaahtac.wooriforei.domain.auth.controller;
 
-import dnaaaaahtac.wooriforei.domain.auth.dto.LoginRequestDTO;
-import dnaaaaahtac.wooriforei.domain.auth.dto.LoginUserResponseDTO;
-import dnaaaaahtac.wooriforei.domain.auth.dto.RegisterAdminRequestDTO;
-import dnaaaaahtac.wooriforei.domain.auth.dto.RegisterUserRequestDTO;
+import dnaaaaahtac.wooriforei.domain.auth.dto.*;
 import dnaaaaahtac.wooriforei.domain.auth.service.AuthService;
 import dnaaaaahtac.wooriforei.global.Jwt.JwtUtil;
 import dnaaaaahtac.wooriforei.global.common.CommonResponse;
@@ -58,6 +55,18 @@ public class AuthController {
 
         return ResponseEntity.ok()
                 .body(CommonResponse.of("사용자 로그인 성공", loginUserResponseDTO));
+    }
+
+    @PostMapping("/admin-login")
+    public ResponseEntity<CommonResponse<LoginAdminResponseDTO>> adminLogin(
+            @RequestBody @Valid LoginRequestDTO requestDTO, HttpServletResponse response) {
+
+        LoginAdminResponseDTO loginAdminResponseDTO = authService.loginAdmin(requestDTO);
+        String jwtToken = jwtUtil.createToken(loginAdminResponseDTO.getAdminName());
+        response.setHeader(HttpHeaders.AUTHORIZATION, jwtToken);
+
+        return ResponseEntity.ok()
+                .body(CommonResponse.of("관리자 로그인 성공", loginAdminResponseDTO));
     }
 
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/LoginAdminResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/LoginAdminResponseDTO.java
@@ -1,0 +1,14 @@
+package dnaaaaahtac.wooriforei.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginAdminResponseDTO {
+
+    private Long adminId;
+    private String adminName;
+    private String adminEmail;
+    private String phoneNumber;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/RegisterAdminRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/dto/RegisterAdminRequestDTO.java
@@ -16,6 +16,9 @@ public class RegisterAdminRequestDTO {
     private String email;
 
     @NotBlank
+    private String adminName;
+
+    @NotBlank
     private String password;
 
     @NotBlank
@@ -51,6 +54,14 @@ public class RegisterAdminRequestDTO {
     }
 
     public void setIsAgreed(boolean agreed) {
+        isAgreed = agreed;
+    }
+
+    public void setAdminName(String adminName) {
+        this.adminName = adminName;
+    }
+
+    public void setAgreed(Boolean agreed) {
         isAgreed = agreed;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/service/AuthService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/service/AuthService.java
@@ -2,10 +2,7 @@ package dnaaaaahtac.wooriforei.domain.auth.service;
 
 import dnaaaaahtac.wooriforei.domain.admin.entity.Admin;
 import dnaaaaahtac.wooriforei.domain.admin.repository.AdminRepository;
-import dnaaaaahtac.wooriforei.domain.auth.dto.LoginRequestDTO;
-import dnaaaaahtac.wooriforei.domain.auth.dto.LoginUserResponseDTO;
-import dnaaaaahtac.wooriforei.domain.auth.dto.RegisterAdminRequestDTO;
-import dnaaaaahtac.wooriforei.domain.auth.dto.RegisterUserRequestDTO;
+import dnaaaaahtac.wooriforei.domain.auth.dto.*;
 import dnaaaaahtac.wooriforei.domain.user.entity.User;
 import dnaaaaahtac.wooriforei.domain.user.repository.UserRepository;
 import dnaaaaahtac.wooriforei.global.Jwt.JwtUtil;
@@ -75,8 +72,9 @@ public class AuthService {
 
         Admin newAdmin = new Admin();
         newAdmin.setAdminEmail(requestDTO.getEmail());
+        newAdmin.setAdminName(requestDTO.getAdminName());
         newAdmin.setPassword(passwordEncoder.encode(requestDTO.getPassword()));
-        newAdmin.setPhone(requestDTO.getPhoneNumber());
+        newAdmin.setPhoneNumber(requestDTO.getPhoneNumber());
         newAdmin.setAgreed(requestDTO.getIsAgreed());
 
         adminRepository.save(newAdmin);
@@ -100,6 +98,23 @@ public class AuthService {
                 .mbti(newUser.getMbti())
                 .birthday(newUser.getBirthday())
                 .nation(newUser.getNation())
+                .build();
+    }
+
+    public LoginAdminResponseDTO loginAdmin(LoginRequestDTO requestDTO) {
+
+        Admin newAdmin = adminRepository.findByAdminEmail(requestDTO.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ADMIN));
+
+        if (!passwordEncoder.matches(requestDTO.getPassword(), newAdmin.getPassword())) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        return LoginAdminResponseDTO.builder()
+                .adminId(newAdmin.getAdminId())
+                .adminName(newAdmin.getAdminName())
+                .adminEmail(newAdmin.getAdminEmail())
+                .phoneNumber(newAdmin.getPhoneNumber())
                 .build();
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
 
     // Admin
     INVALID_SECRET_CODE(400, "비밀 암호가 올바르지 않습니다."),
+    NOT_FOUND_ADMIN(404, "해당 관리자가 존재하지 않습니다."),
 
     // Auth
     PASSWORD_NOT_MATCH(400, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
관리자 로그인 기능을 구현하였습니다. 관리자 로그인은 요청 본문의 차이를 고려하여 별도의 로직과 DTO를 통해 처리되며, 관리자 인증에 성공한 후 응답에는 필요한 정보(관리자 ID, 사용자명, 이메일, 전화번호)를 포함합니다.

### 변경 사항:

* AdminLoginRequestDTO와 LoginAdminResponseDTO를 생성하여 관리자 로그인 요청 및 응답 처리를 위한 구조를 정의했습니다.
* AuthService에 registerAdmin 및 loginAdmin 메소드를 추가하여 관리자의 등록과 로그인을 처리합니다.
* registerAdmin 메소드에는 등록 과정에서 발생할 수 있는 다양한 예외를 처리하는 로직을 포함했습니다.
* loginAdmin 메소드는 관리자 이메일과 비밀번호를 검증하고, 성공 시 LoginAdminResponseDTO를 반환합니다.
* 관리자 로그인 시에도 유효한 JWT 토큰이 응답 헤더에 포함되도록 하였습니다.
데이터베이스에서 'admin_name' 컬럼이 null로 설정되지 않도록, 관련 필드에 적절한 값이 설정되도록 했습니다.

### 테스트:

* 로컬 환경에서 테스트를 통해 관리자 로그인이 성공적으로 이루어지며, JWT 토큰이 올바르게 생성되는 것을 확인했습니다.


리뷰를 부탁드리며, 특별히 주의해야 할 부분이나 의견이 있으시면 알려주세요.