### PR TITLE
Feature/open api information 전체 조회,단건 조회/ seoulGoods openAPI호출, 전체 조회, 단건 조회

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
@@ -1,14 +1,21 @@
 package dnaaaaahtac.wooriforei.domain.openapi.controller;
 
 
-import dnaaaaahtac.wooriforei.domain.openapi.dto.InformationResponseWrapper;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
 import dnaaaaahtac.wooriforei.domain.openapi.service.InformationService;
+import dnaaaaahtac.wooriforei.domain.openapi.service.SeoulGoodsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 
 @RestController
@@ -16,16 +23,60 @@ import reactor.core.publisher.Mono;
 public class OpenApiController {
 
     private final InformationService informationService;
+    private final SeoulGoodsService seoulGoodsService;
 
     @Autowired
-    public OpenApiController(InformationService informationService) {
+    public OpenApiController(InformationService informationService, SeoulGoodsService seoulGoodsService) {
         this.informationService = informationService;
+        this.seoulGoodsService = seoulGoodsService;
     }
 
-    @GetMapping("/information")
-    public Mono<ResponseEntity<InformationResponseWrapper>> information() {
+    //information 호출
+    @GetMapping("/informations")
+    public Mono<ResponseEntity<InformationResponseDto>> information() {
+
         return informationService.retrieveInformation()
-                .map(response -> ResponseEntity.ok().body(response))
-                .defaultIfEmpty(ResponseEntity.notFound().build());
+                .map(response -> ResponseEntity.ok().body(response));
     }
+
+    // information 전체 조회
+    @GetMapping("/informations/check")
+    public ResponseEntity<List<Information>> checkAllInformations() {
+
+        List<Information> informations = informationService.findAllInformations();
+        return ResponseEntity.ok().body(informations);
+    }
+
+    // information 단건 조회
+    @GetMapping("/informations/{informationId}/check")
+    public Mono<ResponseEntity<Information>> checkInformationById(@PathVariable Long informationId) {
+
+        return informationService.findInformationById(informationId)
+                .map(information -> ResponseEntity.ok().body(information));
+    }
+
+    //seoulgoods 호출
+    @GetMapping("/seoulgoods")
+    public Mono<ResponseEntity<SeoulGoodsResponseDto>> seoulGoods() {
+
+        return seoulGoodsService.retrieveSeoulGoods()
+                .map(response -> ResponseEntity.ok().body(response));
+    }
+
+    // seoulgoods 전체 조회
+    @GetMapping("/seoulgoods/check")
+    public ResponseEntity<List<SeoulGoods>> checkAllseoulGoods() {
+
+        List<SeoulGoods> seoulGoods = seoulGoodsService.findAllSeoulGoods();
+        return ResponseEntity.ok().body(seoulGoods);
+    }
+
+    // seoulgoods 단건 조회
+    @GetMapping("/seoulgoods/{seoulgoodsId}/check")
+    public Mono<ResponseEntity<SeoulGoods>> checkseoulGoodsById(@PathVariable Long seoulgoodsId) {
+
+        return seoulGoodsService.findInSeoulGoodsById(seoulgoodsId)
+                .map(seoulGoods -> ResponseEntity.ok().body(seoulGoods));
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/information/InformationDetailDto.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/information/InformationDetailDto.java
@@ -1,5 +1,5 @@
 
-package dnaaaaahtac.wooriforei.domain.openapi.dto;
+package dnaaaaahtac.wooriforei.domain.openapi.dto.information;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class InformationDetailVo {
+public class InformationDetailDto {
 
     @JsonProperty("TRSMICNM")
     private String trsmicnm;
@@ -54,7 +54,7 @@ public class InformationDetailVo {
     private String rdnmadr;
 
     @JsonProperty("LNMADR")
-    private String lnmdr;
+    private String lnmadr;
 
     @JsonProperty("HOMEPAGEURL")
     private String homepageurl;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/information/InformationResponseDto.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/information/InformationResponseDto.java
@@ -1,4 +1,4 @@
-package dnaaaaahtac.wooriforei.domain.openapi.dto;
+package dnaaaaahtac.wooriforei.domain.openapi.dto.information;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class InformationResponseWrapper {
+public class InformationResponseDto {
 
     @JsonProperty("TbTourInformation")
     private InformationResponseVo tbTourInformation;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/information/InformationResponseVo.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/information/InformationResponseVo.java
@@ -1,4 +1,4 @@
-package dnaaaaahtac.wooriforei.domain.openapi.dto;
+package dnaaaaahtac.wooriforei.domain.openapi.dto.information;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -16,6 +16,6 @@ public class InformationResponseVo {
     int listTotalCount;
 
     @JsonProperty("row")
-    ArrayList<InformationDetailVo> row;
+    ArrayList<InformationDetailDto> row;
 
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsDetailDto.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsDetailDto.java
@@ -1,0 +1,43 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SeoulGoodsDetailDto {
+
+    @JsonProperty("NM")
+    private String nm;
+
+    @JsonProperty("ADDR")
+    private String addr;
+
+    @JsonProperty("STATE")
+    private String state;
+
+    @JsonProperty("STOP_DT")
+    private String stopDt;
+
+    @JsonProperty("SUSPENSION_START_DT")
+    private String suspensionStartDt;
+
+    @JsonProperty("SUSPENSION_END_DT")
+    private String suspensionEndDt;
+
+    @JsonProperty("RE_OPEN_DT")
+    private String reOpenDt;
+
+    @JsonProperty("TEL")
+    private String tel;
+
+    @JsonProperty("XCODE")
+    private String xcode;
+
+    @JsonProperty("YCODE")
+    private String ycode;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsResponseDto.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsResponseDto.java
@@ -1,0 +1,16 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SeoulGoodsResponseDto {
+
+    @JsonProperty("frgnrTourGiftShopInfo")
+    private SeoulGoodsResponseVo frgnrtourgiftshopinfo;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsResponseVo.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsResponseVo.java
@@ -1,0 +1,21 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SeoulGoodsResponseVo {
+
+    @JsonProperty("list_total_count")
+    int listTotalCount;
+
+    @JsonProperty("row")
+    ArrayList<SeoulGoodsDetailDto> row;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Activity.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Activity.java
@@ -1,0 +1,4 @@
+package dnaaaaahtac.wooriforei.domain.openapi.entity;
+
+public class Activity {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
@@ -1,0 +1,4 @@
+package dnaaaaahtac.wooriforei.domain.openapi.entity;
+
+public class Hotel {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
@@ -1,0 +1,4 @@
+package dnaaaaahtac.wooriforei.domain.openapi.entity;
+
+public class Landmark {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Restaurant.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Restaurant.java
@@ -1,0 +1,4 @@
+package dnaaaaahtac.wooriforei.domain.openapi.entity;
+
+public class Restaurant {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/SeoulGoods.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/SeoulGoods.java
@@ -1,0 +1,47 @@
+package dnaaaaahtac.wooriforei.domain.openapi.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Entity
+public class SeoulGoods {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String nm;
+
+    @Column
+    private String addr;
+
+    @Column
+    private String state;
+
+    @Column
+    private String stopDt;
+
+    @Column
+    private String suspensionStartDt;
+
+    @Column
+    private String suspensionEndDt;
+
+    @Column
+    private String reOpenDt;
+
+    @Column
+    private String tel;
+
+    @Column
+    private String xcode;
+
+    @Column
+    private String ycode;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/InformationRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/InformationRepository.java
@@ -1,0 +1,14 @@
+package dnaaaaahtac.wooriforei.domain.openapi.repository;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface InformationRepository extends JpaRepository<Information, Long> {
+    // 고유 식별 조합을 통해 정보 조회
+    Optional<Information> findByTrsmicnmAndSigngunm(String trsmicnm, String signgunm);
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/OpenApiRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/OpenApiRepository.java
@@ -1,9 +1,0 @@
-package dnaaaaahtac.wooriforei.domain.openapi.repository;
-
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface OpenApiRepository extends JpaRepository<Information, Long> {
-}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/SeoulGoodsRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/SeoulGoodsRepository.java
@@ -1,0 +1,14 @@
+package dnaaaaahtac.wooriforei.domain.openapi.repository;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SeoulGoodsRepository extends JpaRepository<SeoulGoods, Long> {
+
+    Optional<SeoulGoods> findByNmAndTel(String nm, String tel);
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/InformationService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/InformationService.java
@@ -1,34 +1,213 @@
 package dnaaaaahtac.wooriforei.domain.openapi.service;
 
-import dnaaaaahtac.wooriforei.domain.openapi.dto.InformationResponseWrapper;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationDetailDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+import java.util.Optional;
+
 @Service
 public class InformationService {
 
     private final WebClient webClient;
     private final String authKey;
+    private final InformationRepository informationRepository;
 
     @Autowired
-    public InformationService(WebClient.Builder webClientBuilder,
-                              @Value("${AUTH_KEY}") String authKey) {
+    public InformationService(
+            WebClient.Builder webClientBuilder,
+            @Value("${AUTH_KEY}") String authKey,
+            InformationRepository informationRepository) {
+
         this.webClient = webClientBuilder.baseUrl("http://openapi.seoul.go.kr:8088").build();
         this.authKey = authKey;
+        this.informationRepository = informationRepository;
     }
 
-    public Mono<InformationResponseWrapper> retrieveInformation() {
+    public Mono<InformationResponseDto> retrieveInformation() {
+
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("/{authKey}/{responseType}/{serviceName}/{startIdx}/{endIdx}")
                         .build(authKey, "json", "TbTourInformation", 1, 999))
                 .header("Content-type", "application/json")
                 .retrieve()
-                .bodyToMono(InformationResponseWrapper.class)
-                .doOnSuccess(response -> System.out.println("Successfully retrieved data"))
+                .bodyToMono(InformationResponseDto.class)
+                .doOnSuccess(response -> {
+                    System.out.println("Successfully retrieved data");
+                    saveInformationDetails(response);
+                })
                 .doOnError(e -> System.out.println("Error: " + e.getMessage()));
     }
+
+
+    // 전체 조회
+    public List<Information> findAllInformations() {
+
+        return informationRepository.findAll();
+    }
+
+    // 단건 조회
+    public Mono<Information> findInformationById(Long id) {
+
+        Optional<Information> informationOptional = informationRepository.findById(id);
+
+        // 정보를 찾을 수 없는 경우 예외 발생
+        if (informationOptional.isEmpty()) {
+            return Mono.error(new CustomException(ErrorCode.NOT_FOUND_EXCEPTION));
+        }
+
+        return Mono.justOrEmpty(informationOptional);
+    }
+
+    private void saveInformationDetails(InformationResponseDto wrapper) {
+
+        wrapper.getTbTourInformation().getRow().forEach(this::convertAndSave);
+    }
+
+    private void convertAndSave(InformationDetailDto detail) {
+
+        informationRepository.findByTrsmicnmAndSigngunm(detail.getTrsmicnm(), detail.getSigngunm())
+                .ifPresentOrElse(existingInfo -> updateExistingInformation(existingInfo, detail),
+                        () -> informationRepository.save(mapToEntity(new Information(), detail)));
+    }
+
+    private Information mapToEntity(Information information, InformationDetailDto detail) {
+        // DTO -> Entity 매핑
+        information.setTrsmicnm(detail.getTrsmicnm());
+        information.setSigngunm(detail.getSigngunm());
+        information.setTrsmicintrcn(detail.getTrsmicintrcn());
+        information.setAdisvcinfo(detail.getAdisvcinfo());
+        information.setRstde(detail.getRstde());
+        information.setSummeroperopenhhmm(detail.getSummeroperopenhhmm());
+        information.setSummeroperclosehhmm(detail.getSummeroperclosehhmm());
+        information.setWinteroperopenhhmm(detail.getWinteroperopenhhmm());
+        information.setWinteroperclosehhmm(detail.getWinteroperclosehhmm());
+        information.setEngguidanceyn(detail.getEngguidanceyn());
+        information.setJpguidanceyn(detail.getJpguidanceyn());
+        information.setChguidanceyn(detail.getChguidanceyn());
+        information.setGuidancephonenumber(detail.getGuidancephonenumber());
+        information.setRdnmadr(detail.getRdnmadr());
+        information.setLnmadr(detail.getLnmadr());
+        information.setHomepageurl(detail.getHomepageurl());
+        information.setLatitude(detail.getLatitude());
+        information.setLongitude(detail.getLongitude());
+
+        return information;
+    }
+
+    private void updateExistingInformation(Information existingInfo, InformationDetailDto detail) {
+
+        boolean updated = false;
+
+        if (notEqual(existingInfo.getTrsmicnm(), detail.getTrsmicnm())) {
+            existingInfo.setTrsmicnm(detail.getTrsmicnm());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getSigngunm(), detail.getSigngunm())) {
+            existingInfo.setSigngunm(detail.getSigngunm());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getTrsmicintrcn(), detail.getTrsmicintrcn())) {
+            existingInfo.setTrsmicintrcn(detail.getTrsmicintrcn());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getAdisvcinfo(), detail.getAdisvcinfo())) {
+            existingInfo.setAdisvcinfo(detail.getAdisvcinfo());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getRstde(), detail.getRstde())) {
+            existingInfo.setRstde(detail.getRstde());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getSummeroperopenhhmm(), detail.getSummeroperopenhhmm())) {
+            existingInfo.setSummeroperopenhhmm(detail.getSummeroperopenhhmm());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getSummeroperclosehhmm(), detail.getSummeroperclosehhmm())) {
+            existingInfo.setSummeroperclosehhmm(detail.getSummeroperclosehhmm());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getWinteroperopenhhmm(), detail.getWinteroperopenhhmm())) {
+            existingInfo.setWinteroperopenhhmm(detail.getWinteroperopenhhmm());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getWinteroperclosehhmm(), detail.getWinteroperclosehhmm())) {
+            existingInfo.setWinteroperclosehhmm(detail.getWinteroperclosehhmm());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getEngguidanceyn(), detail.getEngguidanceyn())) {
+            existingInfo.setEngguidanceyn(detail.getEngguidanceyn());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getJpguidanceyn(), detail.getJpguidanceyn())) {
+            existingInfo.setJpguidanceyn(detail.getJpguidanceyn());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getChguidanceyn(), detail.getChguidanceyn())) {
+            existingInfo.setChguidanceyn(detail.getChguidanceyn());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getGuidancephonenumber(), detail.getGuidancephonenumber())) {
+            existingInfo.setGuidancephonenumber(detail.getGuidancephonenumber());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getRdnmadr(), detail.getRdnmadr())) {
+            existingInfo.setRdnmadr(detail.getRdnmadr());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getLnmadr(), detail.getLnmadr())) {
+            existingInfo.setLnmadr(detail.getLnmadr());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getHomepageurl(), detail.getHomepageurl())) {
+            existingInfo.setHomepageurl(detail.getHomepageurl());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getLatitude(), detail.getLatitude())) {
+            existingInfo.setLatitude(detail.getLatitude());
+            updated = true;
+        }
+
+        if (notEqual(existingInfo.getLongitude(), detail.getLongitude())) {
+            existingInfo.setLongitude(detail.getLongitude());
+            updated = true;
+        }
+
+        if (updated) {
+            informationRepository.save(existingInfo);
+
+        }
+    }
+
+    private boolean notEqual(String existingValue, String newValue) {
+
+        return existingValue == null ? newValue != null : !existingValue.equals(newValue);
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
@@ -1,0 +1,164 @@
+package dnaaaaahtac.wooriforei.domain.openapi.service;
+
+import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsDetailDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.SeoulGoodsRepository;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SeoulGoodsService {
+
+    private final WebClient webClient;
+    private final String authKey;
+    private final SeoulGoodsRepository seoulGoodsRepository;
+
+    @Autowired
+    public SeoulGoodsService(
+            WebClient.Builder webClientBuilder,
+            @Value("${AUTH_KEY}") String authKey,
+            SeoulGoodsRepository seoulGoodsRepository) {
+
+        this.webClient = webClientBuilder.baseUrl("http://openapi.seoul.go.kr:8088").build();
+        this.authKey = authKey;
+        this.seoulGoodsRepository = seoulGoodsRepository;
+    }
+
+    public Mono<SeoulGoodsResponseDto> retrieveSeoulGoods() {
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/{authKey}/{responseType}/{serviceName}/{startIdx}/{endIdx}")
+                        .build(authKey, "json", "frgnrTourGiftShopInfo", 1, 999))
+                .header("Content-type", "application/json")
+                .retrieve()
+                .bodyToMono(SeoulGoodsResponseDto.class)
+                .doOnSuccess(response -> {
+                    System.out.println("Successfully retrieved data");
+                    saveSeoulGoodsDetails(response);
+                })
+                .doOnError(e -> System.out.println("Error: " + e.getMessage()));
+    }
+
+
+    // 전체 조회
+    public List<SeoulGoods> findAllSeoulGoods() {
+
+        return seoulGoodsRepository.findAll();
+    }
+
+    // 단건 조회
+    public Mono<SeoulGoods> findInSeoulGoodsById(Long id) {
+
+        Optional<SeoulGoods> SeoulgoodsOptional = seoulGoodsRepository.findById(id);
+
+        // 정보를 찾을 수 없는 경우 예외 발생
+        if (SeoulgoodsOptional.isEmpty()) {
+            return Mono.error(new CustomException(ErrorCode.NOT_FOUND_EXCEPTION));
+        }
+
+        return Mono.justOrEmpty(SeoulgoodsOptional);
+    }
+
+    private void saveSeoulGoodsDetails(SeoulGoodsResponseDto seoulgoodsResponseDto) {
+
+        seoulgoodsResponseDto.getFrgnrtourgiftshopinfo().getRow().forEach(this::convertAndSave);
+    }
+
+    private void convertAndSave(SeoulGoodsDetailDto detail) {
+
+        seoulGoodsRepository.findByNmAndTel(detail.getNm(), detail.getTel())
+                .ifPresentOrElse(existingGoods -> updateExistingSeoulGoods(existingGoods, detail),
+                        () -> seoulGoodsRepository.save(mapToEntity(new SeoulGoods(), detail)));
+    }
+
+    private SeoulGoods mapToEntity(SeoulGoods seoulGoods, SeoulGoodsDetailDto detail) {
+        // DTO -> Entity 매핑
+        seoulGoods.setNm(detail.getNm());
+        seoulGoods.setAddr(detail.getAddr());
+        seoulGoods.setState(detail.getState());
+        seoulGoods.setStopDt(detail.getStopDt());
+        seoulGoods.setSuspensionStartDt(detail.getSuspensionStartDt());
+        seoulGoods.setSuspensionEndDt(detail.getSuspensionEndDt());
+        seoulGoods.setReOpenDt(detail.getReOpenDt());
+        seoulGoods.setTel(detail.getTel());
+        seoulGoods.setXcode(detail.getXcode());
+        seoulGoods.setYcode(detail.getYcode());
+
+        return seoulGoods;
+    }
+
+    private void updateExistingSeoulGoods(SeoulGoods existingGoods, SeoulGoodsDetailDto detail) {
+        boolean updated = false;
+
+        if (notEqual(existingGoods.getNm(), detail.getNm())) {
+            existingGoods.setNm(detail.getNm());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getAddr(), detail.getAddr())) {
+            existingGoods.setAddr(detail.getAddr());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getState(), detail.getState())) {
+            existingGoods.setState(detail.getState());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getStopDt(), detail.getStopDt())) {
+            existingGoods.setStopDt(detail.getStopDt());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getSuspensionStartDt(), detail.getSuspensionStartDt())) {
+            existingGoods.setSuspensionStartDt(detail.getSuspensionStartDt());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getSuspensionEndDt(), detail.getSuspensionEndDt())) {
+            existingGoods.setSuspensionEndDt(detail.getSuspensionEndDt());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getReOpenDt(), detail.getReOpenDt())) {
+            existingGoods.setReOpenDt(detail.getReOpenDt());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getTel(), detail.getTel())) {
+            existingGoods.setTel(detail.getTel());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getXcode(), detail.getXcode())) {
+            existingGoods.setXcode(detail.getXcode());
+            updated = true;
+        }
+
+        if (notEqual(existingGoods.getYcode(), detail.getYcode())) {
+            existingGoods.setYcode(detail.getYcode());
+            updated = true;
+        }
+
+        if (updated) {
+            seoulGoodsRepository.save(existingGoods);
+        }
+    }
+
+    private boolean notEqual(String existingValue, String newValue) {
+
+        return existingValue == null ? newValue != null : !existingValue.equals(newValue);
+    }
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     INVALID_PASSWORD(401, "이메일 또는 비밀번호가 유효하지 않습니다."),
 
     // Board
+    NOT_FOUND_EXCEPTION(404,"게시물이 존재하지 않습니다."),
 
     // Comment
 


### PR DESCRIPTION
1. information 전체 조회, 단건 조회 기능을 구현하였습니다.
2. seoulGoods openAPI 호출, 전체 조회, 단건 조회 기능을 구현하였습니다.
3. 에러 코드를 추가하였습니다.
4. Vo보다 Dto가 적합한 response들의 파일 이름을 수정했습니다.
5. 불러오는 openAPI에 따라 repository를 각각 관리하는것이 데이터 무결성과 유지 보수에 좋을것 이라는 판단하에 OpenApiRepository는 삭제하고 각각의 repository를 만들었습니다.
6. 나머지 openAPI를 위한 entity를 초기 세팅 해두었습니다.