### PR TITLE
feature: hotel, landmark, restaurant API 호출, 전체 조회, 단일 조회 구현 완료

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
@@ -2,12 +2,15 @@ package dnaaaaahtac.wooriforei.domain.openapi.controller;
 
 
 import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.hotel.HotelResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
 import dnaaaaahtac.wooriforei.domain.openapi.service.ActivityService;
+import dnaaaaahtac.wooriforei.domain.openapi.service.HotelService;
 import dnaaaaahtac.wooriforei.domain.openapi.service.InformationService;
 import dnaaaaahtac.wooriforei.domain.openapi.service.SeoulGoodsService;
 import lombok.AllArgsConstructor;
@@ -29,6 +32,7 @@ public class OpenApiController {
     private final InformationService informationService;
     private final SeoulGoodsService seoulGoodsService;
     private final ActivityService activityService;
+    private final HotelService hotelService;
 
     //information 호출
     @GetMapping("/informations")
@@ -52,7 +56,7 @@ public class OpenApiController {
     public Mono<ResponseEntity<Information>> checkInformationById(@PathVariable Long informationId) {
 
         return informationService.findInformationById(informationId)
-                .map(information -> ResponseEntity.ok().body(information));
+                .map(response -> ResponseEntity.ok().body(response));
     }
 
     //seoulgoods 호출
@@ -77,7 +81,7 @@ public class OpenApiController {
     public Mono<ResponseEntity<SeoulGoods>> checkSeoulGoodsById(@PathVariable Long seoulgoodsId) {
 
         return seoulGoodsService.findInSeoulGoodsById(seoulgoodsId)
-                .map(seoulGoods -> ResponseEntity.ok().body(seoulGoods));
+                .map(response -> ResponseEntity.ok().body(response));
     }
 
     //activity 호출
@@ -99,9 +103,32 @@ public class OpenApiController {
 
     //activity 단일 조회
     @GetMapping("/activities/{activitiesId}/check")
-    public Mono<ResponseEntity<Activity>> checkActivitiesById(@PathVariable Long activitiesId) {
+    public Mono<ResponseEntity<Activity>> checkActivitiesById (@PathVariable Long activitiesId) {
 
         return activityService.findActivityById(activitiesId)
-                .map(activity -> ResponseEntity.ok().body(activity));
+                .map(response -> ResponseEntity.ok().body(response));
     }
+
+    @GetMapping("/hotels")
+    public Mono<ResponseEntity<HotelResponseDTO>> hotels(){
+
+        return hotelService.retrieveHotel()
+                .map(response -> ResponseEntity.ok().body(response));
+    }
+
+    @GetMapping("/hotels/check")
+    public ResponseEntity<List<Hotel>> checkALLHotels(){
+
+        List<Hotel> hotels = hotelService.findAllHotels();
+
+        return ResponseEntity.ok().body(hotels);
+    }
+
+    @GetMapping("/hotels/{hotelId}/check")
+    public Mono<ResponseEntity<Hotel>> checkHotelsById (@PathVariable Long hotelId){
+
+        return hotelService.findHotelById(hotelId)
+                .map(response -> ResponseEntity.ok().body(response));
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
@@ -1,18 +1,16 @@
 package dnaaaaahtac.wooriforei.domain.openapi.controller;
 
 
-import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDto;
-import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDto;
-import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
-import dnaaaaahtac.wooriforei.domain.openapi.repository.ActivityRepository;
 import dnaaaaahtac.wooriforei.domain.openapi.service.ActivityService;
 import dnaaaaahtac.wooriforei.domain.openapi.service.InformationService;
 import dnaaaaahtac.wooriforei.domain.openapi.service.SeoulGoodsService;
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,7 +32,7 @@ public class OpenApiController {
 
     //information 호출
     @GetMapping("/informations")
-    public Mono<ResponseEntity<InformationResponseDto>> information() {
+    public Mono<ResponseEntity<InformationResponseDTO>> information() {
 
         return informationService.retrieveInformation()
                 .map(response -> ResponseEntity.ok().body(response));
@@ -45,10 +43,11 @@ public class OpenApiController {
     public ResponseEntity<List<Information>> checkAllInformations() {
 
         List<Information> informations = informationService.findAllInformations();
+
         return ResponseEntity.ok().body(informations);
     }
 
-    // information 단건 조회
+    // information 단일 조회
     @GetMapping("/informations/{informationId}/check")
     public Mono<ResponseEntity<Information>> checkInformationById(@PathVariable Long informationId) {
 
@@ -58,7 +57,7 @@ public class OpenApiController {
 
     //seoulgoods 호출
     @GetMapping("/seoulgoods")
-    public Mono<ResponseEntity<SeoulGoodsResponseDto>> seoulGoods() {
+    public Mono<ResponseEntity<SeoulGoodsResponseDTO>> seoulGoods() {
 
         return seoulGoodsService.retrieveSeoulGoods()
                 .map(response -> ResponseEntity.ok().body(response));
@@ -69,10 +68,11 @@ public class OpenApiController {
     public ResponseEntity<List<SeoulGoods>> checkAllSeoulGoods() {
 
         List<SeoulGoods> seoulGoods = seoulGoodsService.findAllSeoulGoods();
+
         return ResponseEntity.ok().body(seoulGoods);
     }
 
-    // seoulgoods 단건 조회
+    // seoulgoods 단일 조회
     @GetMapping("/seoulgoods/{seoulgoodsId}/check")
     public Mono<ResponseEntity<SeoulGoods>> checkSeoulGoodsById(@PathVariable Long seoulgoodsId) {
 
@@ -82,7 +82,7 @@ public class OpenApiController {
 
     //activity 호출
     @GetMapping("/activities")
-    public Mono<ResponseEntity<ActivityResponseDto>> activities(){
+    public Mono<ResponseEntity<ActivityResponseDTO>> activities(){
 
         return activityService.retrieveActivity()
                 .map(response -> ResponseEntity.ok().body(response));
@@ -93,10 +93,11 @@ public class OpenApiController {
     public ResponseEntity<List<Activity>> checkAllActivities(){
 
         List<Activity> activities = activityService.findAllActivity();
+
         return ResponseEntity.ok().body(activities);
     }
 
-    //activity 단건 조회
+    //activity 단일 조회
     @GetMapping("/activities/{activitiesId}/check")
     public Mono<ResponseEntity<Activity>> checkActivitiesById(@PathVariable Long activitiesId) {
 

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.Optional;
 
 
 @RestController
@@ -129,9 +128,9 @@ public class OpenApiController {
     }
 
     @GetMapping("/landmarks")
-    public Mono<ResponseEntity<LandmarkResponseDTO>> landmarks(){
-
-        return landmarkService.retrieveHotel()
+    public Mono<ResponseEntity<List<LandmarkResponseDTO>>> landmarks() {
+        return landmarkService.retrieveLandmarkPage()
+                .collectList()  // Flux를 List로 변환
                 .map(response -> ResponseEntity.ok().body(response));
     }
 
@@ -143,7 +142,7 @@ public class OpenApiController {
         return ResponseEntity.ok().body(landmarks);
     }
 
-    @GetMapping("/landmark/{landmarkId}/check")
+    @GetMapping("/landmarks/{landmarkId}/check")
     public Mono<ResponseEntity<Landmark>> checkRestaurantById(@PathVariable Long landmarkId){
 
         return landmarkService.findLandmarkById(landmarkId)

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
@@ -5,6 +5,7 @@ import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.hotel.HotelResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.landmark.LandmarkResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.restaurant.RestaurantResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.*;
 import dnaaaaahtac.wooriforei.domain.openapi.service.*;
@@ -29,6 +30,7 @@ public class OpenApiController {
     private final ActivityService activityService;
     private final HotelService hotelService;
     private final LandmarkService landmarkService;
+    private final RestaurantService restaurantService;
 
     //information 호출
     @GetMapping("/informations")
@@ -143,10 +145,34 @@ public class OpenApiController {
     }
 
     @GetMapping("/landmarks/{landmarkId}/check")
-    public Mono<ResponseEntity<Landmark>> checkRestaurantById(@PathVariable Long landmarkId){
+    public Mono<ResponseEntity<Landmark>> checkLandmarkById(@PathVariable Long landmarkId){
 
         return landmarkService.findLandmarkById(landmarkId)
                 .map(reponse -> ResponseEntity.ok().body(reponse));
     }
+
+    @GetMapping("/restaurants")
+    public Mono<ResponseEntity<List<RestaurantResponseDTO>>> restaurants() {
+
+        return restaurantService.retrieveRestaurantPage()
+                .collectList()
+                .map(response ->ResponseEntity.ok().body(response));
+    }
+
+    @GetMapping("/restaurants/check")
+    public ResponseEntity<List<Restaurant>> checkAllRestaurant() {
+
+        List<Restaurant> restaurants = restaurantService.findAllRestaurant();
+
+        return ResponseEntity.ok().body(restaurants);
+    }
+
+    @GetMapping("/restaurants/{restaurantId}/check")
+    public Mono<ResponseEntity<Restaurant>> checkRestaurantById (@PathVariable Long restaurantId) {
+
+        return restaurantService.findRestaurantById(restaurantId)
+                .map(response -> ResponseEntity.ok().body(response));
+    }
+
 
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/controller/OpenApiController.java
@@ -4,15 +4,10 @@ package dnaaaaahtac.wooriforei.domain.openapi.controller;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.hotel.HotelResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.landmark.LandmarkResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDTO;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
-import dnaaaaahtac.wooriforei.domain.openapi.service.ActivityService;
-import dnaaaaahtac.wooriforei.domain.openapi.service.HotelService;
-import dnaaaaahtac.wooriforei.domain.openapi.service.InformationService;
-import dnaaaaahtac.wooriforei.domain.openapi.service.SeoulGoodsService;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.*;
+import dnaaaaahtac.wooriforei.domain.openapi.service.*;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.Optional;
 
 
 @RestController
@@ -33,6 +29,7 @@ public class OpenApiController {
     private final SeoulGoodsService seoulGoodsService;
     private final ActivityService activityService;
     private final HotelService hotelService;
+    private final LandmarkService landmarkService;
 
     //information 호출
     @GetMapping("/informations")
@@ -129,6 +126,28 @@ public class OpenApiController {
 
         return hotelService.findHotelById(hotelId)
                 .map(response -> ResponseEntity.ok().body(response));
+    }
+
+    @GetMapping("/landmarks")
+    public Mono<ResponseEntity<LandmarkResponseDTO>> landmarks(){
+
+        return landmarkService.retrieveHotel()
+                .map(response -> ResponseEntity.ok().body(response));
+    }
+
+    @GetMapping("/landmarks/check")
+    public ResponseEntity<List<Landmark>> checkAllLandmark(){
+
+        List<Landmark> landmarks = landmarkService.findAllLandmarks();
+
+        return ResponseEntity.ok().body(landmarks);
+    }
+
+    @GetMapping("/landmark/{landmarkId}/check")
+    public Mono<ResponseEntity<Landmark>> checkRestaurantById(@PathVariable Long landmarkId){
+
+        return landmarkService.findLandmarkById(landmarkId)
+                .map(reponse -> ResponseEntity.ok().body(reponse));
     }
 
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/hotel/HotelDetailDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/hotel/HotelDetailDTO.java
@@ -1,0 +1,27 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.hotel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class HotelDetailDTO {
+
+    @JsonProperty("MAIN_KEY")
+    String mainKey;
+
+    @JsonProperty("CATE3_NAME")
+    String cate3Name;
+
+    @JsonProperty("NAME_KOR")
+    String nameKor;
+
+    @JsonProperty("H_KOR_CITY")
+    String hKorCity;
+
+    @JsonProperty("H_KOR_GU")
+    String hKorGu;
+
+    @JsonProperty("H_KOR_DONG")
+    String hKorDong;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/hotel/HotelResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/hotel/HotelResponseDTO.java
@@ -1,0 +1,11 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.hotel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class HotelResponseDTO {
+
+    @JsonProperty("SebcHotelListKor")
+    HotelResponseVO SebcHotelListKor;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/hotel/HotelResponseVO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/hotel/HotelResponseVO.java
@@ -1,0 +1,17 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.hotel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.ArrayList;
+
+@Getter
+public class HotelResponseVO {
+
+    @JsonProperty("list_total_count")
+    int listTotalCount;
+
+    @JsonProperty("row")
+    ArrayList<HotelDetailDTO> row;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/landmark/LandmarkDetailDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/landmark/LandmarkDetailDTO.java
@@ -1,0 +1,45 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.landmark;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class LandmarkDetailDTO {
+
+    @JsonProperty("POST_SN")
+    String postSn;
+
+    @JsonProperty("LANG_CODE_ID")
+    String langCodeId;
+
+    @JsonProperty("POST_SJ")
+    String postSj;
+
+    @JsonProperty("ADDRESS")
+    String address;
+
+    @JsonProperty("NEW_ADDRESS")
+    String newAddress;
+
+    @JsonProperty("CMMN_TELNO")
+    String cmmnTelno;
+
+    @JsonProperty("CMMN_HMPG_URL")
+    String cmmnHmpgUrl;
+
+    @JsonProperty("CMMN_USE_TIME")
+    String CmmnUseTime;
+
+    @JsonProperty("CMMN_BSNDE")
+    String cmmnBsnde;
+
+    @JsonProperty("CMMN_RSTDE")
+    String cmmnRstde;
+
+    @JsonProperty("SUBWAY_INFO")
+    String subwayInfo;
+
+    @JsonProperty("BF_DESC")
+    String bfDesc;
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/landmark/LandmarkResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/landmark/LandmarkResponseDTO.java
@@ -1,0 +1,11 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.landmark;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class LandmarkResponseDTO {
+
+    @JsonProperty("TbVwAttractions")
+    LandmarkResponseVO TbVwAttractions;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/landmark/LandmarkResponseVO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/landmark/LandmarkResponseVO.java
@@ -1,0 +1,16 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.landmark;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.ArrayList;
+
+@Getter
+public class LandmarkResponseVO {
+
+    @JsonProperty("list_total_count")
+    int listTotalCount;
+
+    @JsonProperty("row")
+    ArrayList<LandmarkDetailDTO> row;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/restaurant/RestaurantDetailDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/restaurant/RestaurantDetailDTO.java
@@ -1,0 +1,40 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.restaurant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class RestaurantDetailDTO {
+
+    @JsonProperty("POST_SN")
+    String postSn;
+
+    @JsonProperty("LANG_CODE_ID")
+    String langCodeId;
+
+    @JsonProperty("POST_SJ")
+    String postSj;
+
+    @JsonProperty("ADDRESS")
+    String address;
+
+    @JsonProperty("NEW_ADDRESS")
+    String newAddress;
+
+    @JsonProperty("CMMN_TELNO")
+    String cmmnTelNo;
+
+    @JsonProperty("CMMN_HMPG_URL")
+    String cmmnHmpgUrl;
+
+    @JsonProperty("CMMN_USE_TIME")
+    String cmmnUseTime;
+
+    @JsonProperty("SUBWAY_INFO")
+    String subwayInfo;
+
+    @JsonProperty("FD_REPRSNT_MENU")
+    String fdReprsntMenu;
+
+}
+

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/restaurant/RestaurantResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/restaurant/RestaurantResponseDTO.java
@@ -1,0 +1,11 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.restaurant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class RestaurantResponseDTO {
+
+    @JsonProperty("TbVwRestaurants")
+    RestaurantResponseVO TbVwRestaurants;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/restaurant/RestaurantResponseVO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/restaurant/RestaurantResponseVO.java
@@ -1,0 +1,16 @@
+package dnaaaaahtac.wooriforei.domain.openapi.dto.restaurant;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.ArrayList;
+
+@Getter
+public class RestaurantResponseVO {
+
+    @JsonProperty("list_total_count")
+    int listTotalCount;
+
+    @JsonProperty("row")
+    ArrayList<RestaurantDetailDTO> row;
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/dto/seoulgoods/SeoulGoodsResponseDTO.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 public class SeoulGoodsResponseDTO {
 
     @JsonProperty("frgnrTourGiftShopInfo")
-    private SeoulGoodsResponseVO frgnrtourgiftshopinfo;
+    private SeoulGoodsResponseVO frgnrTourGiftShopInfo;
 
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Activity.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Activity.java
@@ -11,7 +11,7 @@ public class Activity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long activityId;
 
     @Column
     private String svcid;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
@@ -11,7 +11,7 @@ public class Hotel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long hotelId;
 
     @Column
     private String mainKey;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
@@ -1,6 +1,5 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Hotel.java
@@ -1,4 +1,35 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
 public class Hotel {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String mainKey;
+
+    @Column
+    private String cate3Name;
+
+    @Column
+    private String nameKor;
+
+    @Column
+    private String hKorCity;
+
+    @Column
+    private String hKorGu;
+
+    @Column
+    private String hKorDong;
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Information.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Information.java
@@ -11,7 +11,7 @@ public class Information {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long informationId;
 
     @Column
     private String trsmicnm;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Information.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Information.java
@@ -1,6 +1,5 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
@@ -1,4 +1,53 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
 public class Landmark {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String postSn;
+
+    @Column
+    private String langCodeId;
+
+    @Column
+    private String postSj;
+
+    @Column
+    private String address;
+
+    @Column
+    private String newAddress;
+
+    @Column
+    private String cmmnTelno;
+
+    @Column
+    private String cmmnHmpgUrl;
+
+    @Column
+    private String CmmnUseTime;
+
+    @Column
+    private String cmmnBsnde;
+
+    @Column
+    private String cmmnRstde;
+
+    @Column
+    private String subwayInfo;
+
+    @Column
+    private String bfDesc;
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
@@ -1,6 +1,5 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Landmark.java
@@ -11,7 +11,7 @@ public class Landmark {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long randmarkId;
 
     @Column
     private String postSn;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Restaurant.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Restaurant.java
@@ -1,4 +1,46 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
 public class Restaurant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    @Column
+    String postSn;
+
+    @Column
+    String langCodeId;
+
+    @Column
+    String postSj;
+
+    @Column
+    String address;
+
+    @Column
+    String newAddress;
+
+    @Column
+    String cmmnTelno;
+
+    @Column
+    String cmmnHmpgUrl;
+
+    @Column
+    String cmmnUseTime;
+
+    @Column
+    String subwayInfo;
+
+    @Column
+    String fdReprsntMenu;
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Restaurant.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/Restaurant.java
@@ -11,7 +11,7 @@ public class Restaurant {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long restaurantId;
 
     @Column
     String postSn;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/SeoulGoods.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/SeoulGoods.java
@@ -1,6 +1,5 @@
 package dnaaaaahtac.wooriforei.domain.openapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/SeoulGoods.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/entity/SeoulGoods.java
@@ -11,7 +11,7 @@ public class SeoulGoods {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long seoulGoodsId;
 
     @Column
     private String nm;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/HotelRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/HotelRepository.java
@@ -1,0 +1,13 @@
+package dnaaaaahtac.wooriforei.domain.openapi.repository;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface HotelRepository extends JpaRepository<Hotel, Long> {
+
+    Optional<Hotel> findByMainKey(String mainKey);
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/InformationRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/InformationRepository.java
@@ -1,7 +1,6 @@
 package dnaaaaahtac.wooriforei.domain.openapi.repository;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/LandmarkRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/LandmarkRepository.java
@@ -1,0 +1,14 @@
+package dnaaaaahtac.wooriforei.domain.openapi.repository;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Landmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LandmarkRepository extends JpaRepository<Landmark, Long> {
+
+    Optional<Landmark> findByPostSn (String postSn);
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/RestaurantRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/repository/RestaurantRepository.java
@@ -1,0 +1,13 @@
+package dnaaaaahtac.wooriforei.domain.openapi.repository;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Restaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
+
+    Optional<Restaurant> findByPostSn (String postSn);
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/ActivityService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/ActivityService.java
@@ -9,6 +9,7 @@ import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -78,12 +79,14 @@ public class ActivityService {
         return Mono.justOrEmpty(activityOptional);
     }
 
-    private void saveActivityDetails(ActivityResponseDTO wrapper) {
+    @Transactional
+    public void saveActivityDetails(ActivityResponseDTO wrapper) {
 
         wrapper.getListPublicReservationCulture().getRow().forEach(this::convertAndSave);
     }
 
-    private void convertAndSave(ActivityDetailDTO detail) {
+    @Transactional
+    public void convertAndSave(ActivityDetailDTO detail) {
 
         activityRepository.findBySvcid(detail.getSvcid())
                 .ifPresentOrElse(existingAct -> updateExistingActivity(existingAct, detail),

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/ActivityService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/ActivityService.java
@@ -1,8 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.openapi.service;
 
-import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityDetailDto;
-import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDto;
-import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.activity.ActivityResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.ActivityRepository;
 import dnaaaaahtac.wooriforei.global.exception.CustomException;
@@ -44,7 +43,7 @@ public class ActivityService {
         this.activityRepository = activityRepository;
     }
 
-    public Mono<ActivityResponseDto> retrieveActivity() {
+    public Mono<ActivityResponseDTO> retrieveActivity() {
 
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -52,7 +51,7 @@ public class ActivityService {
                         .build(authKey, "json", "ListPublicReservationCulture", 1, 999))
                 .header("Content-type", "application/json")
                 .retrieve()
-                .bodyToMono(ActivityResponseDto.class)
+                .bodyToMono(ActivityResponseDTO.class)
                 .doOnSuccess(response -> {
                     System.out.println("Successfully retrieved data");
                     saveActivityDetails(response);
@@ -79,19 +78,19 @@ public class ActivityService {
         return Mono.justOrEmpty(activityOptional);
     }
 
-    private void saveActivityDetails(ActivityResponseDto wrapper) {
+    private void saveActivityDetails(ActivityResponseDTO wrapper) {
 
         wrapper.getListPublicReservationCulture().getRow().forEach(this::convertAndSave);
     }
 
-    private void convertAndSave(ActivityDetailDto detail) {
+    private void convertAndSave(ActivityDetailDTO detail) {
 
         activityRepository.findBySvcid(detail.getSvcid())
                 .ifPresentOrElse(existingAct -> updateExistingActivity(existingAct, detail),
                         () -> activityRepository.save(mapToEntity(new Activity(), detail)));
     }
 
-    private Activity mapToEntity(Activity activity, ActivityDetailDto detail) {
+    private Activity mapToEntity(Activity activity, ActivityDetailDTO detail) {
         // DTO -> Entity 매핑
         activity.setSvcid(detail.getSvcid());
         activity.setMinclassnm(detail.getMinclassnm());
@@ -116,7 +115,7 @@ public class ActivityService {
         return activity;
     }
 
-    private void updateExistingActivity(Activity existingAct, ActivityDetailDto detail) {
+    private void updateExistingActivity(Activity existingAct, ActivityDetailDTO detail) {
         boolean updated = false;
 
         if (notEqual(existingAct.getSvcid(), detail.getSvcid())) {

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/HotelService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/HotelService.java
@@ -1,0 +1,143 @@
+package dnaaaaahtac.wooriforei.domain.openapi.service;
+
+import dnaaaaahtac.wooriforei.domain.openapi.dto.hotel.HotelDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.hotel.HotelResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.HotelRepository;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class HotelService {
+
+    private final WebClient webClient;
+    private final String authKey;
+    private final HotelRepository hotelRepository;
+
+    @Autowired
+    public HotelService(
+            WebClient.Builder webClientBuilder,
+            @Value("${AUTH_KEY}") String authKey,
+            HotelRepository hotelRepository) {
+
+        this.webClient = webClientBuilder.baseUrl("http://openapi.seoul.go.kr:8088").build();
+        this.authKey = authKey;
+        this.hotelRepository = hotelRepository;
+    }
+
+    public Mono<HotelResponseDTO> retrieveHotel() {
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/{authKey}/{responseType}/{serviceName}/{startIdx}/{endIdx}")
+                        .build(authKey, "json", "SebcHotelListKor", 1, 999))
+                .header("Content-type", "application/json")
+                .retrieve()
+                .bodyToMono(HotelResponseDTO.class)
+                .doOnSuccess(response -> {
+                    System.out.println("Successfully retrieved data");
+                    saveHotelDetails(response);
+                })
+                .doOnError(e -> System.out.println("Error: " + e.getMessage()));
+    }
+
+    // 전체 조회
+    public List<Hotel> findAllHotels() {
+
+        return hotelRepository.findAll();
+    }
+
+    // 단건 조회
+    public Mono<Hotel> findHotelById(Long id) {
+
+        Optional<Hotel> HotelOptional = hotelRepository.findById(id);
+
+        // 정보를 찾을 수 없는 경우 예외 발생
+        if (HotelOptional.isEmpty()) {
+            return Mono.error(new CustomException(ErrorCode.NOT_FOUND_DATA));
+        }
+
+        return Mono.justOrEmpty(HotelOptional);
+    }
+
+    @Transactional
+    public void saveHotelDetails(HotelResponseDTO wrapper) {
+
+        wrapper.getSebcHotelListKor().getRow().forEach(this::convertAndSave);
+    }
+
+    @Transactional
+    public void convertAndSave(HotelDetailDTO detail) {
+
+        hotelRepository.findByMainKey(detail.getMainKey())
+                .ifPresentOrElse(existingHotel -> updateExistingHotel(existingHotel, detail),
+                        () -> hotelRepository.save(mapToEntity(new Hotel(), detail)));
+    }
+
+    private Hotel mapToEntity(Hotel hotel, HotelDetailDTO detail) {
+        // DTO -> Entity 매핑
+        hotel.setMainKey(detail.getMainKey());
+        hotel.setCate3Name(detail.getCate3Name());
+        hotel.setNameKor(detail.getNameKor());
+        hotel.setHKorCity(detail.getHKorCity());
+        hotel.setHKorGu(detail.getHKorGu());
+        hotel.setHKorDong(detail.getHKorDong());
+
+        return hotel;
+    }
+
+    private void updateExistingHotel(Hotel existingHotel, HotelDetailDTO detail) {
+
+        boolean updated = false;
+
+        if (notEqual(existingHotel.getMainKey(), detail.getMainKey())) {
+            existingHotel.setMainKey(detail.getMainKey());
+            updated = true;
+        }
+
+        if (notEqual(existingHotel.getCate3Name(), detail.getCate3Name())) {
+            existingHotel.setCate3Name(detail.getCate3Name());
+            updated = true;
+        }
+
+        if (notEqual(existingHotel.getNameKor(), detail.getNameKor())) {
+            existingHotel.setNameKor(detail.getNameKor());
+            updated = true;
+        }
+
+        if (notEqual(existingHotel.getHKorCity(), detail.getHKorCity())) {
+            existingHotel.setHKorCity(detail.getHKorCity());
+            updated = true;
+        }
+
+        if (notEqual(existingHotel.getHKorGu(), detail.getHKorGu())) {
+            existingHotel.setHKorGu(detail.getHKorGu());
+            updated = true;
+        }
+
+        if (notEqual(existingHotel.getHKorDong(), detail.getHKorDong())) {
+            existingHotel.setHKorDong(detail.getHKorDong());
+            updated = true;
+        }
+
+        if (updated) {
+            hotelRepository.save(existingHotel);
+
+        }
+    }
+
+    private boolean notEqual(String existingValue, String newValue) {
+
+        return existingValue == null ? newValue != null : !existingValue.equals(newValue);
+    }
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/InformationService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/InformationService.java
@@ -1,7 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.openapi.service;
 
-import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationDetailDto;
-import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.information.InformationResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
 import dnaaaaahtac.wooriforei.global.exception.CustomException;
@@ -33,7 +33,7 @@ public class InformationService {
         this.informationRepository = informationRepository;
     }
 
-    public Mono<InformationResponseDto> retrieveInformation() {
+    public Mono<InformationResponseDTO> retrieveInformation() {
 
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -41,7 +41,7 @@ public class InformationService {
                         .build(authKey, "json", "TbTourInformation", 1, 999))
                 .header("Content-type", "application/json")
                 .retrieve()
-                .bodyToMono(InformationResponseDto.class)
+                .bodyToMono(InformationResponseDTO.class)
                 .doOnSuccess(response -> {
                     System.out.println("Successfully retrieved data");
                     saveInformationDetails(response);
@@ -69,19 +69,19 @@ public class InformationService {
         return Mono.justOrEmpty(informationOptional);
     }
 
-    private void saveInformationDetails(InformationResponseDto wrapper) {
+    private void saveInformationDetails(InformationResponseDTO wrapper) {
 
         wrapper.getTbTourInformation().getRow().forEach(this::convertAndSave);
     }
 
-    private void convertAndSave(InformationDetailDto detail) {
+    private void convertAndSave(InformationDetailDTO detail) {
 
         informationRepository.findByTrsmicnmAndSigngunm(detail.getTrsmicnm(), detail.getSigngunm())
                 .ifPresentOrElse(existingInfo -> updateExistingInformation(existingInfo, detail),
                         () -> informationRepository.save(mapToEntity(new Information(), detail)));
     }
 
-    private Information mapToEntity(Information information, InformationDetailDto detail) {
+    private Information mapToEntity(Information information, InformationDetailDTO detail) {
         // DTO -> Entity 매핑
         information.setTrsmicnm(detail.getTrsmicnm());
         information.setSigngunm(detail.getSigngunm());
@@ -105,7 +105,7 @@ public class InformationService {
         return information;
     }
 
-    private void updateExistingInformation(Information existingInfo, InformationDetailDto detail) {
+    private void updateExistingInformation(Information existingInfo, InformationDetailDTO detail) {
 
         boolean updated = false;
 

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/InformationService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/InformationService.java
@@ -9,6 +9,7 @@ import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -49,7 +50,6 @@ public class InformationService {
                 .doOnError(e -> System.out.println("Error: " + e.getMessage()));
     }
 
-
     // 전체 조회
     public List<Information> findAllInformations() {
 
@@ -69,12 +69,14 @@ public class InformationService {
         return Mono.justOrEmpty(informationOptional);
     }
 
-    private void saveInformationDetails(InformationResponseDTO wrapper) {
+    @Transactional
+    public void saveInformationDetails(InformationResponseDTO wrapper) {
 
         wrapper.getTbTourInformation().getRow().forEach(this::convertAndSave);
     }
 
-    private void convertAndSave(InformationDetailDTO detail) {
+    @Transactional
+    public void convertAndSave(InformationDetailDTO detail) {
 
         informationRepository.findByTrsmicnmAndSigngunm(detail.getTrsmicnm(), detail.getSigngunm())
                 .ifPresentOrElse(existingInfo -> updateExistingInformation(existingInfo, detail),

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/LandmarkService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/LandmarkService.java
@@ -1,0 +1,181 @@
+package dnaaaaahtac.wooriforei.domain.openapi.service;
+
+import dnaaaaahtac.wooriforei.domain.openapi.dto.hotel.HotelDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.landmark.LandmarkDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.landmark.LandmarkResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Landmark;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.LandmarkRepository;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class LandmarkService {
+
+    private final WebClient webClient;
+    private final String authKey;
+    private final LandmarkRepository landmarkRepository;
+
+    @Autowired
+    public LandmarkService(
+            WebClient.Builder webClientBuilder,
+            @Value("${AUTH_KEY}") String authKey,
+            LandmarkRepository landmarkRepository) {
+
+        this.webClient = webClientBuilder.baseUrl("http://openapi.seoul.go.kr:8088").build();
+        this.authKey = authKey;
+        this.landmarkRepository = landmarkRepository;
+    }
+
+    public Mono<LandmarkResponseDTO> retrieveHotel() {
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/{authKey}/{responseType}/{serviceName}/{startIdx}/{endIdx}")
+                        .build(authKey, "json", "SebcHotelListKor", 1, 999))
+                .header("Content-type", "application/json")
+                .retrieve()
+                .bodyToMono(LandmarkResponseDTO.class)
+                .doOnSuccess(response -> {
+                    System.out.println("Successfully retrieved data");
+                    saveLandmarkDetails(response);
+                })
+                .doOnError(e -> System.out.println("Error: " + e.getMessage()));
+    }
+
+    // 전체 조회
+    public List<Landmark> findAllLandmarks() {
+
+        return landmarkRepository.findAll();
+    }
+
+    // 단건 조회
+    public Mono<Landmark> findLandmarkById(Long id) {
+
+        Optional<Landmark> LandmarkOptional = landmarkRepository.findById(id);
+
+        // 정보를 찾을 수 없는 경우 예외 발생
+        if (LandmarkOptional.isEmpty()) {
+            return Mono.error(new CustomException(ErrorCode.NOT_FOUND_DATA));
+        }
+
+        return Mono.justOrEmpty(LandmarkOptional);
+    }
+
+    @Transactional
+    public void saveLandmarkDetails(LandmarkResponseDTO wrapper) {
+
+        wrapper.getTbVwAttractions().getRow().forEach(this::convertAndSave);
+    }
+
+    @Transactional
+    public void convertAndSave(LandmarkDetailDTO detail) {
+
+        landmarkRepository.findByPostSn(detail.getPostSn())
+                .ifPresentOrElse(existingLandmark -> updateExistingLandmark(existingLandmark, detail),
+                        () -> landmarkRepository.save(mapToEntity(new Landmark(), detail)));
+    }
+
+    private Landmark mapToEntity(Landmark landmark, LandmarkDetailDTO detail) {
+        // DTO -> Entity 매핑
+        landmark.setPostSn(detail.getPostSn());
+        landmark.setLangCodeId(detail.getLangCodeId());
+        landmark.setPostSj(detail.getPostSj());
+        landmark.setAddress(detail.getAddress());
+        landmark.setNewAddress(detail.getNewAddress());
+        landmark.setCmmnTelno(detail.getCmmnTelno());
+        landmark.setCmmnHmpgUrl(detail.getCmmnHmpgUrl());
+        landmark.setCmmnUseTime(detail.getCmmnUseTime());
+        landmark.setCmmnBsnde(detail.getCmmnBsnde());
+        landmark.setCmmnRstde(detail.getCmmnRstde());
+        landmark.setSubwayInfo(detail.getSubwayInfo());
+        landmark.setBfDesc(detail.getBfDesc());
+
+        return landmark;
+    }
+
+    private void updateExistingLandmark(Landmark existingLandmark, LandmarkDetailDTO detail) {
+
+        boolean updated = false;
+
+        if (notEqual(existingLandmark.getPostSn(), detail.getPostSn())) {
+            existingLandmark.setPostSn(detail.getPostSn());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getLangCodeId(), detail.getLangCodeId())) {
+            existingLandmark.setLangCodeId(detail.getLangCodeId());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getPostSj(), detail.getPostSj())) {
+            existingLandmark.setPostSj(detail.getPostSj());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getAddress(), detail.getAddress())) {
+            existingLandmark.setAddress(detail.getAddress());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getNewAddress(), detail.getNewAddress())) {
+            existingLandmark.setNewAddress(detail.getNewAddress());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getCmmnTelno(), detail.getCmmnTelno())) {
+            existingLandmark.setCmmnTelno(detail.getCmmnTelno());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getCmmnHmpgUrl(), detail.getCmmnHmpgUrl())) {
+            existingLandmark.setCmmnHmpgUrl(detail.getCmmnHmpgUrl());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getCmmnUseTime(), detail.getCmmnUseTime())) {
+            existingLandmark.setCmmnUseTime(detail.getCmmnUseTime());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getCmmnBsnde(), detail.getCmmnBsnde())) {
+            existingLandmark.setCmmnBsnde(detail.getCmmnBsnde());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getCmmnRstde(), detail.getCmmnRstde())) {
+            existingLandmark.setCmmnRstde(detail.getCmmnRstde());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getSubwayInfo(), detail.getSubwayInfo())) {
+            existingLandmark.setSubwayInfo(detail.getSubwayInfo());
+            updated = true;
+        }
+
+        if (notEqual(existingLandmark.getBfDesc(), detail.getBfDesc())) {
+            existingLandmark.setBfDesc(detail.getBfDesc());
+            updated = true;
+        }
+
+        if (updated) {
+            landmarkRepository.save(existingLandmark);
+
+        }
+    }
+
+    private boolean notEqual(String existingValue, String newValue) {
+
+        return existingValue == null ? newValue != null : !existingValue.equals(newValue);
+    }
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/RestaurantService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/RestaurantService.java
@@ -1,0 +1,200 @@
+package dnaaaaahtac.wooriforei.domain.openapi.service;
+
+import dnaaaaahtac.wooriforei.domain.openapi.dto.restaurant.RestaurantDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.restaurant.RestaurantResponseDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Restaurant;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.RestaurantRepository;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class RestaurantService {
+
+    private final WebClient webClient;
+    private final String authKey;
+    private final RestaurantRepository restaurantRepository;
+
+    @Autowired
+    public RestaurantService(
+            WebClient.Builder webClientBuilder,
+            @Value("${AUTH_KEY}") String authKey,
+            RestaurantRepository restaurantRepository) {
+
+        ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+                .codecs(clientCodecConfigurer -> clientCodecConfigurer
+                        .defaultCodecs()
+                        .maxInMemorySize(16 * 1024 * 1024)) // 16MB로 설정
+                .build();
+
+        this.webClient = webClientBuilder
+                .baseUrl("http://openapi.seoul.go.kr:8088")
+                .exchangeStrategies(exchangeStrategies)
+                .build();
+        this.authKey = authKey;
+        this.restaurantRepository = restaurantRepository;
+    }
+
+    public Flux<RestaurantResponseDTO> retrieveRestaurantPage() {
+
+        int totalItems = 5999;
+        int pageSize = 1000;
+
+        // 총 페이지 수 계산
+        int totalPages = (totalItems + pageSize - 1) / pageSize;
+
+        return Flux.range(1, totalPages)
+                .flatMap(page -> {
+                    int startIdx = (page - 1) * pageSize + 1;
+                    int endIdx = startIdx + pageSize - 1;
+                    if (endIdx > totalItems) {
+                        endIdx = totalItems;
+                    }
+                    return retrieveRestaurant(startIdx, endIdx);
+                });
+    }
+
+    private Mono<RestaurantResponseDTO> retrieveRestaurant(int startIdx, int endIdx) {
+
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/{authKey}/{responseType}/{serviceName}/{startIdx}/{endIdx}")
+                        .build(authKey, "json", "TbVwRestaurants", startIdx, endIdx))
+                .header("Content-type", "application/json")
+                .retrieve()
+                .bodyToMono(RestaurantResponseDTO.class)
+                .doOnSuccess(response -> {
+                    System.out.println("Successfully retrieved data from " + startIdx + " to " + endIdx);
+                    saveRestaurantDetails(response);
+                })
+                .doOnError(e -> System.out.println("Error retrieving data from " + startIdx + " to " + endIdx + ": " + e.getMessage()));
+    }
+
+    // 전체 조회
+    public List<Restaurant> findAllRestaurant() {
+
+        return restaurantRepository.findAll();
+    }
+
+    // 단건 조회
+    public Mono<Restaurant> findRestaurantById(Long id) {
+
+        Optional<Restaurant> restaurantOptional = restaurantRepository.findById(id);
+
+        // 정보를 찾을 수 없는 경우 예외 발생
+        if (restaurantOptional.isEmpty()) {
+            return Mono.error(new CustomException(ErrorCode.NOT_FOUND_DATA));
+        }
+
+        return Mono.justOrEmpty(restaurantOptional);
+    }
+
+    @Transactional
+    public void saveRestaurantDetails(RestaurantResponseDTO response) {
+
+        response.getTbVwRestaurants().getRow().stream()
+                .filter(detail -> "ko".equals(detail.getLangCodeId()))
+                .forEach(this::convertAndSave);
+    }
+
+    @Transactional
+    public void convertAndSave(RestaurantDetailDTO detail) {
+
+        restaurantRepository.findByPostSn(detail.getPostSn())
+                .ifPresentOrElse(existingRest -> updateExistingRestaurant(existingRest, detail),
+                        () -> restaurantRepository.save(mapToEntity(new Restaurant(), detail)));
+    }
+
+    private Restaurant mapToEntity(Restaurant restaurant, RestaurantDetailDTO detail) {
+        // DTO -> Entity 매핑
+        restaurant.setPostSn(detail.getPostSn());
+        restaurant.setLangCodeId(detail.getLangCodeId());
+        restaurant.setPostSj(detail.getPostSj());
+        restaurant.setAddress(detail.getAddress());
+        restaurant.setNewAddress(detail.getNewAddress());
+        restaurant.setCmmnTelno(detail.getCmmnTelNo());
+        restaurant.setCmmnHmpgUrl(detail.getCmmnHmpgUrl());
+        restaurant.setCmmnUseTime(detail.getCmmnUseTime());
+        restaurant.setSubwayInfo(detail.getSubwayInfo());
+        restaurant.setFdReprsntMenu(detail.getFdReprsntMenu());
+
+        return restaurant;
+    }
+
+    private void updateExistingRestaurant(Restaurant existingRest, RestaurantDetailDTO detail) {
+
+        boolean updated = false;
+
+        if (notEqual(existingRest.getPostSn(), detail.getPostSn())) {
+            existingRest.setPostSn(detail.getPostSn());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getLangCodeId(), detail.getLangCodeId())) {
+            existingRest.setLangCodeId(detail.getLangCodeId());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getPostSj(), detail.getPostSj())) {
+            existingRest.setPostSj(detail.getPostSj());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getAddress(), detail.getAddress())) {
+            existingRest.setAddress(detail.getAddress());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getNewAddress(), detail.getNewAddress())) {
+            existingRest.setNewAddress(detail.getNewAddress());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getCmmnTelno(), detail.getCmmnTelNo())) {
+            existingRest.setCmmnTelno(detail.getCmmnTelNo());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getCmmnHmpgUrl(), detail.getCmmnHmpgUrl())) {
+            existingRest.setCmmnHmpgUrl(detail.getCmmnHmpgUrl());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getCmmnUseTime(), detail.getCmmnUseTime())) {
+            existingRest.setCmmnUseTime(detail.getCmmnUseTime());
+            updated = true;
+        }
+
+
+        if (notEqual(existingRest.getSubwayInfo(), detail.getSubwayInfo())) {
+            existingRest.setSubwayInfo(detail.getSubwayInfo());
+            updated = true;
+        }
+
+        if (notEqual(existingRest.getFdReprsntMenu(), detail.getFdReprsntMenu())) {
+            existingRest.setFdReprsntMenu(detail.getFdReprsntMenu());
+            updated = true;
+        }
+
+        if (updated) {
+            restaurantRepository.save(existingRest);
+
+        }
+    }
+
+    private boolean notEqual(String existingValue, String newValue) {
+
+        return existingValue == null ? newValue != null : !existingValue.equals(newValue);
+    }
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
@@ -50,7 +50,6 @@ public class SeoulGoodsService {
                 .doOnError(e -> System.out.println("Error: " + e.getMessage()));
     }
 
-
     // 전체 조회
     public List<SeoulGoods> findAllSeoulGoods() {
 

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
@@ -1,9 +1,8 @@
 package dnaaaaahtac.wooriforei.domain.openapi.service;
 
-import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsDetailDto;
-import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDto;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsDetailDTO;
+import dnaaaaahtac.wooriforei.domain.openapi.dto.seoulgoods.SeoulGoodsResponseDTO;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
-import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.SeoulGoodsRepository;
 import dnaaaaahtac.wooriforei.global.exception.CustomException;
 import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
@@ -34,7 +33,7 @@ public class SeoulGoodsService {
         this.seoulGoodsRepository = seoulGoodsRepository;
     }
 
-    public Mono<SeoulGoodsResponseDto> retrieveSeoulGoods() {
+    public Mono<SeoulGoodsResponseDTO> retrieveSeoulGoods() {
 
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
@@ -42,7 +41,7 @@ public class SeoulGoodsService {
                         .build(authKey, "json", "frgnrTourGiftShopInfo", 1, 999))
                 .header("Content-type", "application/json")
                 .retrieve()
-                .bodyToMono(SeoulGoodsResponseDto.class)
+                .bodyToMono(SeoulGoodsResponseDTO.class)
                 .doOnSuccess(response -> {
                     System.out.println("Successfully retrieved data");
                     saveSeoulGoodsDetails(response);
@@ -70,19 +69,19 @@ public class SeoulGoodsService {
         return Mono.justOrEmpty(SeoulgoodsOptional);
     }
 
-    private void saveSeoulGoodsDetails(SeoulGoodsResponseDto seoulgoodsResponseDto) {
+    private void saveSeoulGoodsDetails(SeoulGoodsResponseDTO seoulgoodsResponseDto) {
 
         seoulgoodsResponseDto.getFrgnrtourgiftshopinfo().getRow().forEach(this::convertAndSave);
     }
 
-    private void convertAndSave(SeoulGoodsDetailDto detail) {
+    private void convertAndSave(SeoulGoodsDetailDTO detail) {
 
         seoulGoodsRepository.findByNmAndTel(detail.getNm(), detail.getTel())
                 .ifPresentOrElse(existingGoods -> updateExistingSeoulGoods(existingGoods, detail),
                         () -> seoulGoodsRepository.save(mapToEntity(new SeoulGoods(), detail)));
     }
 
-    private SeoulGoods mapToEntity(SeoulGoods seoulGoods, SeoulGoodsDetailDto detail) {
+    private SeoulGoods mapToEntity(SeoulGoods seoulGoods, SeoulGoodsDetailDTO detail) {
         // DTO -> Entity 매핑
         seoulGoods.setNm(detail.getNm());
         seoulGoods.setAddr(detail.getAddr());
@@ -98,7 +97,7 @@ public class SeoulGoodsService {
         return seoulGoods;
     }
 
-    private void updateExistingSeoulGoods(SeoulGoods existingGoods, SeoulGoodsDetailDto detail) {
+    private void updateExistingSeoulGoods(SeoulGoods existingGoods, SeoulGoodsDetailDTO detail) {
         boolean updated = false;
 
         if (notEqual(existingGoods.getNm(), detail.getNm())) {

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/openapi/service/SeoulGoodsService.java
@@ -9,6 +9,7 @@ import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -69,12 +70,14 @@ public class SeoulGoodsService {
         return Mono.justOrEmpty(SeoulgoodsOptional);
     }
 
-    private void saveSeoulGoodsDetails(SeoulGoodsResponseDTO seoulgoodsResponseDto) {
+    @Transactional
+    public void saveSeoulGoodsDetails(SeoulGoodsResponseDTO seoulgoodsResponseDto) {
 
-        seoulgoodsResponseDto.getFrgnrtourgiftshopinfo().getRow().forEach(this::convertAndSave);
+        seoulgoodsResponseDto.getFrgnrTourGiftShopInfo().getRow().forEach(this::convertAndSave);
     }
 
-    private void convertAndSave(SeoulGoodsDetailDTO detail) {
+    @Transactional
+    public void convertAndSave(SeoulGoodsDetailDTO detail) {
 
         seoulGoodsRepository.findByNmAndTel(detail.getNm(), detail.getTel())
                 .ifPresentOrElse(existingGoods -> updateExistingSeoulGoods(existingGoods, detail),


### PR DESCRIPTION
1. hotel, landmark, restaurant API 호출, 전체 조회, 단일 조회 구현 완료 했습니다.
2. service단에 트랜잭션 추가했습니다.
3. openAPI로 한번에 받아올수 있는 양이 1000건이기 때문에 1000건이상인 landmark, restaurant 은 서비스단에서 Mono 타입이 아닌 Flux로 여러번 받아올수 있도록 변경하였습니다.
4. landmark와 restaurant는 DB에 저장해야 하는양이 너무 많아 한글("ko") 타입만 받아올수 있도록 필터하는 로직을 service에 추가하였습니다.