### PR TITLE
feature: scheduler + openAPI

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/Schedulable.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/Schedulable.java
@@ -1,0 +1,11 @@
+package dnaaaaahtac.wooriforei.domain.scheduler;
+
+import java.time.LocalDateTime;
+
+public interface Schedulable {
+    Long getEventId();
+
+    LocalDateTime getStartTime();
+
+    LocalDateTime getEndTime();
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -115,4 +115,14 @@ public class SchedulerController {
 
         return ResponseEntity.ok(CommonResponse.of("스케줄러에 맛집 추가 성공", null));
     }
+
+    @PostMapping("/{schedulerId}/seoul-goods")
+    public ResponseEntity<CommonResponse<Void>> addSeoulGoodsToScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody SchedulerSeoulGoodsRequestDTO seoulGoodsDTO) {
+
+        schedulerService.addSeoulGoodsToScheduler(schedulerId, seoulGoodsDTO);
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러에 기념품판매소 추가 성공", null));
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.controller;
 
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerActivityRequestDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerHotelRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.service.SchedulerService;
@@ -74,5 +75,16 @@ public class SchedulerController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("스케줄러에 문화체험 추가 성공", null));
+    }
+
+    @PostMapping("/{schedulerId}/hotels")
+    public ResponseEntity<CommonResponse<Void>> addHotelToScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody @Valid SchedulerHotelRequestDTO hotelDTO) {
+
+        schedulerService.addHotelToScheduler(schedulerId, hotelDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("스케줄러에 호텔 추가 성공", null));
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/schedulers")
 @RequiredArgsConstructor
@@ -36,4 +38,10 @@ public class SchedulerController {
         return ResponseEntity.ok(CommonResponse.of("스케줄러 단일 조회 성공", scheduler));
     }
 
+    @GetMapping
+    public ResponseEntity<CommonResponse<List<SchedulerResponseDTO>>> getAllSchedulers() {
+        List<SchedulerResponseDTO> schedulers = schedulerService.getAllSchedulers();
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러 전체 조회 성공", schedulers));
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -94,4 +94,15 @@ public class SchedulerController {
 
         return ResponseEntity.ok(CommonResponse.of("스케줄러에 안내소 추가 성공", null));
     }
+
+    @PostMapping("/{schedulerId}/landmarks")
+    public ResponseEntity<CommonResponse<Void>> addLandmarkToScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody @Valid SchedulerLandmarkRequestDTO landmarkDTO) {
+
+        schedulerService.addLandmarkToScheduler(schedulerId, landmarkDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("스케줄러에 명소 추가 성공", null));
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -1,17 +1,14 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.controller;
 
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateResponseDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.service.SchedulerService;
 import dnaaaaahtac.wooriforei.global.common.CommonResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/schedulers")
@@ -21,12 +18,22 @@ public class SchedulerController {
     private final SchedulerService schedulerService;
 
     @PostMapping
-    public ResponseEntity<CommonResponse<SchedulerCreateResponseDTO>> createScheduler(
+    public ResponseEntity<CommonResponse<SchedulerResponseDTO>> createScheduler(
             @RequestBody @Valid SchedulerCreateRequestDTO schedulerCreateRequestDTO) {
 
-        SchedulerCreateResponseDTO schedulerResponse = schedulerService.createScheduler(schedulerCreateRequestDTO);
+        SchedulerResponseDTO schedulerResponse = schedulerService.createScheduler(schedulerCreateRequestDTO);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("스케줄러 생성 성공", schedulerResponse));
     }
+
+    @GetMapping("/{schedulerId}")
+    public ResponseEntity<CommonResponse<SchedulerResponseDTO>> getScheduler(
+            @PathVariable Long schedulerId) {
+
+        SchedulerResponseDTO scheduler = schedulerService.getSchedulerById(schedulerId);
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러 단일 조회 성공", scheduler));
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -1,5 +1,6 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.controller;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerActivityRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.service.SchedulerService;
@@ -56,11 +57,22 @@ public class SchedulerController {
     }
 
     @DeleteMapping("/{schedulerId}")
-    public ResponseEntity<CommonResponse<String>> deleteScheduler(
+    public ResponseEntity<CommonResponse<Void>> deleteScheduler(
             @PathVariable Long schedulerId) {
 
         schedulerService.deleteScheduler(schedulerId);
 
         return ResponseEntity.ok(CommonResponse.of("스케줄러 삭제 성공", null));
+    }
+
+    @PostMapping("/{schedulerId}/activities")
+    public ResponseEntity<CommonResponse<Void>> addActivityToScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody @Valid SchedulerActivityRequestDTO activityDTO) {
+
+        schedulerService.addActivityToScheduler(schedulerId, activityDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("스케줄러에 문화체험 추가 성공", null));
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -1,0 +1,32 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.controller;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateRequestDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateResponseDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.service.SchedulerService;
+import dnaaaaahtac.wooriforei.global.common.CommonResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/schedulers")
+@RequiredArgsConstructor
+public class SchedulerController {
+
+    private final SchedulerService schedulerService;
+
+    @PostMapping
+    public ResponseEntity<CommonResponse<SchedulerCreateResponseDTO>> createScheduler(
+            @RequestBody @Valid SchedulerCreateRequestDTO schedulerCreateRequestDTO) {
+
+        SchedulerCreateResponseDTO schedulerResponse = schedulerService.createScheduler(schedulerCreateRequestDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CommonResponse.of("스케줄러 생성 성공", schedulerResponse));
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -54,4 +54,13 @@ public class SchedulerController {
 
         return ResponseEntity.ok(CommonResponse.of("스케줄러 수정 성공", updatedScheduler));
     }
+
+    @DeleteMapping("/{schedulerId}")
+    public ResponseEntity<CommonResponse<String>> deleteScheduler(
+            @PathVariable Long schedulerId) {
+
+        schedulerService.deleteScheduler(schedulerId);
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러 삭제 성공", null));
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -1,9 +1,6 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.controller;
 
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerActivityRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerHotelRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.*;
 import dnaaaaahtac.wooriforei.domain.scheduler.service.SchedulerService;
 import dnaaaaahtac.wooriforei.global.common.CommonResponse;
 import jakarta.validation.Valid;
@@ -86,5 +83,15 @@ public class SchedulerController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("스케줄러에 호텔 추가 성공", null));
+    }
+
+    @PostMapping("/{schedulerId}/information")
+    public ResponseEntity<CommonResponse<Void>> addInformationToScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody SchedulerInformationRequestDTO informationDTO) {
+
+        schedulerService.addInformationToScheduler(schedulerId, informationDTO);
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러에 안내소 추가 성공", null));
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -105,4 +105,14 @@ public class SchedulerController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("스케줄러에 명소 추가 성공", null));
     }
+
+    @PostMapping("/{schedulerId}/restaurants")
+    public ResponseEntity<CommonResponse<Void>> addRestaurantToScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody SchedulerRestaurantRequestDTO restaurantDTO) {
+
+        schedulerService.addRestaurantToScheduler(schedulerId, restaurantDTO);
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러에 맛집 추가 성공", null));
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/controller/SchedulerController.java
@@ -1,6 +1,6 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.controller;
 
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateRequestDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.service.SchedulerService;
 import dnaaaaahtac.wooriforei.global.common.CommonResponse;
@@ -21,9 +21,9 @@ public class SchedulerController {
 
     @PostMapping
     public ResponseEntity<CommonResponse<SchedulerResponseDTO>> createScheduler(
-            @RequestBody @Valid SchedulerCreateRequestDTO schedulerCreateRequestDTO) {
+            @RequestBody @Valid SchedulerRequestDTO schedulerRequestDTO) {
 
-        SchedulerResponseDTO schedulerResponse = schedulerService.createScheduler(schedulerCreateRequestDTO);
+        SchedulerResponseDTO schedulerResponse = schedulerService.createScheduler(schedulerRequestDTO);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(CommonResponse.of("스케줄러 생성 성공", schedulerResponse));
@@ -43,5 +43,15 @@ public class SchedulerController {
         List<SchedulerResponseDTO> schedulers = schedulerService.getAllSchedulers();
 
         return ResponseEntity.ok(CommonResponse.of("스케줄러 전체 조회 성공", schedulers));
+    }
+
+    @PutMapping("/{schedulerId}")
+    public ResponseEntity<CommonResponse<SchedulerResponseDTO>> updateScheduler(
+            @PathVariable Long schedulerId,
+            @RequestBody @Valid SchedulerRequestDTO schedulerRequestDTO) {
+
+        SchedulerResponseDTO updatedScheduler = schedulerService.updateScheduler(schedulerId, schedulerRequestDTO);
+
+        return ResponseEntity.ok(CommonResponse.of("스케줄러 수정 성공", updatedScheduler));
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerActivityRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerActivityRequestDTO.java
@@ -1,0 +1,27 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulerActivityRequestDTO {
+
+    private Long activityId;
+
+    private LocalDateTime visitStart;
+
+    private LocalDateTime visitEnd;
+
+    public void setActivityId(Long activityId) {
+        this.activityId = activityId;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerCreateRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerCreateRequestDTO.java
@@ -1,0 +1,39 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class SchedulerCreateRequestDTO {
+
+    @NotBlank(message = "스케줄러 이름은 필수입니다.")
+    private String schedulerName;
+
+    @NotNull(message = "시작 날짜는 필수입니다.")
+    private LocalDateTime startDate;
+
+    @NotNull(message = "종료 날짜는 필수입니다.")
+    private LocalDateTime endDate;
+
+    private List<String> memberEmails;
+
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = schedulerName;
+    }
+
+    public void setStartDate(LocalDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
+    }
+
+    public void setMemberEmails(List<String> memberEmails) {
+        this.memberEmails = memberEmails;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerCreateResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerCreateResponseDTO.java
@@ -1,0 +1,49 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import dnaaaaahtac.wooriforei.domain.user.dto.UserDetailResponseDTO;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SchedulerCreateResponseDTO {
+
+    private Long schedulerId;
+    private String schedulerName;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private List<UserDetailResponseDTO> members;
+
+    public void setSchedulerId(Long schedulerId) {
+        this.schedulerId = schedulerId;
+    }
+
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = schedulerName;
+    }
+
+    public void setStartDate(LocalDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public void setModifiedAt(LocalDateTime modifiedAt) {
+        this.modifiedAt = modifiedAt;
+    }
+
+    public void setMembers(List<UserDetailResponseDTO> members) {
+        this.members = members;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerHotelRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerHotelRequestDTO.java
@@ -1,0 +1,27 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulerHotelRequestDTO {
+
+    private Long hotelId;
+
+    private LocalDateTime stayStart;
+
+    private LocalDateTime stayEnd;
+
+    public void setHotelId(Long hotelId) {
+        this.hotelId = hotelId;
+    }
+
+    public void setStayStart(LocalDateTime stayStart) {
+        this.stayStart = stayStart;
+    }
+
+    public void setStayEnd(LocalDateTime stayEnd) {
+        this.stayEnd = stayEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerInformationRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerInformationRequestDTO.java
@@ -1,0 +1,27 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulerInformationRequestDTO {
+
+    private Long informationId;
+
+    private LocalDateTime visitStart;
+
+    private LocalDateTime visitEnd;
+
+    public void setInformationId(Long informationId) {
+        this.informationId = informationId;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerLandmarkRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerLandmarkRequestDTO.java
@@ -1,0 +1,31 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulerLandmarkRequestDTO {
+
+    @NotNull
+    private Long landmarkId;
+
+    @NotNull
+    private LocalDateTime visitStart;
+
+    @NotNull
+    private LocalDateTime visitEnd;
+
+    public void setLandmarkId(Long landmarkId) {
+        this.landmarkId = landmarkId;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerRequestDTO.java
@@ -2,24 +2,32 @@ package dnaaaaahtac.wooriforei.domain.scheduler.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-public class SchedulerCreateRequestDTO {
+public class SchedulerRequestDTO {
 
-    @NotBlank(message = "스케줄러 이름은 필수입니다.")
+    @NotBlank(message = "스케줄러 이름은 필수입니다.", groups = Create.class)
+    @Size(min = 1, message = "스케줄러 이름은 최소 1글자 이상이어야 합니다.", groups = Update.class)
     private String schedulerName;
 
-    @NotNull(message = "시작 날짜는 필수입니다.")
+    @NotNull(message = "시작 날짜는 필수입니다.", groups = Create.class)
     private LocalDateTime startDate;
 
-    @NotNull(message = "종료 날짜는 필수입니다.")
+    @NotNull(message = "종료 날짜는 필수입니다.", groups = Create.class)
     private LocalDateTime endDate;
 
     private List<String> memberEmails;
+
+    public interface Create {
+    }
+
+    public interface Update {
+    }
 
     public void setSchedulerName(String schedulerName) {
         this.schedulerName = schedulerName;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerResponseDTO.java
@@ -18,6 +18,37 @@ public class SchedulerResponseDTO {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private List<UserDetailResponseDTO> members;
+    private List<OpenAPIDetailsDTO> openAPIs;
+
+    @Getter
+    public static class OpenAPIDetailsDTO {
+        private Long id;
+        private String name;
+        private LocalDateTime visitStart;
+        private LocalDateTime visitEnd;
+        private String type;
+
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setVisitStart(LocalDateTime visitStart) {
+            this.visitStart = visitStart;
+        }
+
+        public void setVisitEnd(LocalDateTime visitEnd) {
+            this.visitEnd = visitEnd;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
 
     public void setSchedulerId(Long schedulerId) {
         this.schedulerId = schedulerId;
@@ -45,5 +76,9 @@ public class SchedulerResponseDTO {
 
     public void setMembers(List<UserDetailResponseDTO> members) {
         this.members = members;
+    }
+
+    public void setOpenAPIs(List<OpenAPIDetailsDTO> openAPIs) {
+        this.openAPIs = openAPIs;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerResponseDTO.java
@@ -29,20 +29,51 @@ public class SchedulerResponseDTO {
         private String type;
 
 
+        public OpenAPIDetailsDTO() {
+        }
+
+        public OpenAPIDetailsDTO(Long id, String name, LocalDateTime visitStart, LocalDateTime visitEnd, String type) {
+            this.id = id;
+            this.name = name;
+            this.visitStart = visitStart;
+            this.visitEnd = visitEnd;
+            this.type = type;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
         public void setId(Long id) {
             this.id = id;
+        }
+
+        public String getName() {
+            return name;
         }
 
         public void setName(String name) {
             this.name = name;
         }
 
+        public LocalDateTime getVisitStart() {
+            return visitStart;
+        }
+
         public void setVisitStart(LocalDateTime visitStart) {
             this.visitStart = visitStart;
         }
 
+        public LocalDateTime getVisitEnd() {
+            return visitEnd;
+        }
+
         public void setVisitEnd(LocalDateTime visitEnd) {
             this.visitEnd = visitEnd;
+        }
+
+        public String getType() {
+            return type;
         }
 
         public void setType(String type) {

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerResponseDTO.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class SchedulerCreateResponseDTO {
+public class SchedulerResponseDTO {
 
     private Long schedulerId;
     private String schedulerName;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerRestaurantRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerRestaurantRequestDTO.java
@@ -1,0 +1,31 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulerRestaurantRequestDTO {
+
+    @NotNull
+    private Long restaurantId;
+
+    @NotNull
+    private LocalDateTime visitStart;
+
+    @NotNull
+    private LocalDateTime visitEnd;
+
+    public void setRestaurantId(Long restaurantId) {
+        this.restaurantId = restaurantId;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerSeoulGoodsRequestDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/dto/SchedulerSeoulGoodsRequestDTO.java
@@ -1,0 +1,31 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class SchedulerSeoulGoodsRequestDTO {
+
+    @NotNull
+    private Long goodsId;
+
+    @NotNull
+    private LocalDateTime visitStart;
+
+    @NotNull
+    private LocalDateTime visitEnd;
+
+    public void setGoodsId(Long goodsId) {
+        this.goodsId = goodsId;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/Scheduler.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/Scheduler.java
@@ -1,4 +1,42 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
-public class Scheduler {
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "Schedulers")
+public class Scheduler extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long schedulerId;
+
+    @Column(nullable = false)
+    private String schedulerName;
+
+    @Column(nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(nullable = false)
+    private LocalDateTime endDate;
+
+    public void setSchedulerId(Long schedulerId) {
+        this.schedulerId = schedulerId;
+    }
+
+    public void setSchedulerName(String schedulerName) {
+        this.schedulerName = schedulerName;
+    }
+
+    public void setStartDate(LocalDateTime startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/Scheduler.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/Scheduler.java
@@ -1,10 +1,13 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -24,6 +27,24 @@ public class Scheduler extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime endDate;
 
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulerActivity> schedulerActivities = new ArrayList<>();
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulerHotel> schedulerHotels = new ArrayList<>();
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulerInformation> schedulerInformations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulerLandmark> schedulerLandmarks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulerRestaurant> schedulerRestaurants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "scheduler", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulerSeoulGoods> schedulerSeoulGoods = new ArrayList<>();
+
     public void setSchedulerId(Long schedulerId) {
         this.schedulerId = schedulerId;
     }
@@ -39,4 +60,17 @@ public class Scheduler extends BaseTimeEntity {
     public void setEndDate(LocalDateTime endDate) {
         this.endDate = endDate;
     }
+
+    public List<Schedulable> getEvents() {
+        List<Schedulable> events = new ArrayList<>();
+        events.addAll(this.schedulerActivities);
+        events.addAll(this.schedulerHotels);
+        events.addAll(this.schedulerInformations);
+        events.addAll(this.schedulerLandmarks);
+        events.addAll(this.schedulerRestaurants);
+        events.addAll(this.schedulerSeoulGoods);
+
+        return events;
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerActivity.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerActivity.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -9,7 +10,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "SchedulerActivities")
-public class SchedulerActivity {
+public class SchedulerActivity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerActivity.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerActivity.java
@@ -1,0 +1,61 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "SchedulerActivities")
+public class SchedulerActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long schedulerActivityId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedulerId")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activityId")
+    private Activity activity;
+
+    @Column(nullable = false)
+    private LocalDateTime visitStart;
+
+    @Column(nullable = false)
+    private LocalDateTime visitEnd;
+
+    public SchedulerActivity() {
+    }
+
+    public SchedulerActivity(Scheduler scheduler, Activity activity, LocalDateTime visitStart, LocalDateTime visitEnd) {
+        this.scheduler = scheduler;
+        this.activity = activity;
+        this.visitStart = visitStart;
+        this.visitEnd = visitEnd;
+    }
+
+    public void setSchedulerActivityId(Long schedulerActivityId) {
+        this.schedulerActivityId = schedulerActivityId;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setActivity(Activity activity) {
+        this.activity = activity;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerActivity.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerActivity.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "SchedulerActivities")
-public class SchedulerActivity extends BaseTimeEntity {
+public class SchedulerActivity extends BaseTimeEntity implements Schedulable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,5 +59,20 @@ public class SchedulerActivity extends BaseTimeEntity {
 
     public void setVisitEnd(LocalDateTime visitEnd) {
         this.visitEnd = visitEnd;
+    }
+
+    @Override
+    public Long getEventId() {
+        return this.schedulerActivityId;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.visitStart;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return this.visitEnd;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerHotel.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerHotel.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "SchedulerHotels")
-public class SchedulerHotel extends BaseTimeEntity {
+public class SchedulerHotel extends BaseTimeEntity implements Schedulable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,5 +59,20 @@ public class SchedulerHotel extends BaseTimeEntity {
 
     public void setStayEnd(LocalDateTime stayEnd) {
         this.stayEnd = stayEnd;
+    }
+
+    @Override
+    public Long getEventId() {
+        return this.id;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.stayStart;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return this.stayEnd;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerHotel.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerHotel.java
@@ -1,0 +1,62 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "SchedulerHotels")
+public class SchedulerHotel extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedulerId")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hotelId")
+    private Hotel hotel;
+
+    @Column(nullable = false)
+    private LocalDateTime stayStart;
+
+    @Column(nullable = false)
+    private LocalDateTime stayEnd;
+
+    public SchedulerHotel(Scheduler scheduler, Hotel hotel, LocalDateTime stayStart, LocalDateTime stayEnd) {
+        this.scheduler = scheduler;
+        this.hotel = hotel;
+        this.stayStart = stayStart;
+        this.stayEnd = stayEnd;
+    }
+
+    protected SchedulerHotel() {
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setHotel(Hotel hotel) {
+        this.hotel = hotel;
+    }
+
+    public void setStayStart(LocalDateTime stayStart) {
+        this.stayStart = stayStart;
+    }
+
+    public void setStayEnd(LocalDateTime stayEnd) {
+        this.stayEnd = stayEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerInformation.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerInformation.java
@@ -1,0 +1,62 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "SchedulerInformations")
+public class SchedulerInformation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedulerId")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "informationId")
+    private Information information;
+
+    @Column(nullable = false)
+    private LocalDateTime visitStart;
+
+    @Column(nullable = false)
+    private LocalDateTime visitEnd;
+
+    protected SchedulerInformation() {
+    }
+
+    public SchedulerInformation(Scheduler scheduler, Information information, LocalDateTime visitStart, LocalDateTime visitEnd) {
+        this.scheduler = scheduler;
+        this.information = information;
+        this.visitStart = visitStart;
+        this.visitEnd = visitEnd;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setInformation(Information information) {
+        this.information = information;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerInformation.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerInformation.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "SchedulerInformations")
-public class SchedulerInformation extends BaseTimeEntity {
+public class SchedulerInformation extends BaseTimeEntity implements Schedulable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -58,5 +59,20 @@ public class SchedulerInformation extends BaseTimeEntity {
 
     public void setVisitEnd(LocalDateTime visitEnd) {
         this.visitEnd = visitEnd;
+    }
+
+    @Override
+    public Long getEventId() {
+        return this.id;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.visitStart;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return this.visitEnd;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerLandmark.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerLandmark.java
@@ -1,0 +1,71 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Landmark;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "SchedulerLandmarks")
+public class SchedulerLandmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "scheduler_id")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "landmark_id")
+    private Landmark landmark;
+
+    @Column(nullable = false)
+    private LocalDateTime visitStart;
+
+    @Column(nullable = false)
+    private LocalDateTime visitEnd;
+
+    public SchedulerLandmark() {
+    }
+
+    public SchedulerLandmark(Scheduler scheduler, Landmark landmark, LocalDateTime visitStart, LocalDateTime visitEnd) {
+        this.scheduler = scheduler;
+        this.landmark = landmark;
+        this.visitStart = visitStart;
+        this.visitEnd = visitEnd;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Scheduler getScheduler() {
+        return scheduler;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setLandmark(Landmark landmark) {
+        this.landmark = landmark;
+    }
+
+    public void setVisitStart(LocalDateTime visitStart) {
+        this.visitStart = visitStart;
+    }
+
+    public void setVisitEnd(LocalDateTime visitEnd) {
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerLandmark.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerLandmark.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Landmark;
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "SchedulerLandmarks")
-public class SchedulerLandmark extends BaseTimeEntity {
+public class SchedulerLandmark extends BaseTimeEntity implements Schedulable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -67,5 +68,20 @@ public class SchedulerLandmark extends BaseTimeEntity {
 
     public void setVisitEnd(LocalDateTime visitEnd) {
         this.visitEnd = visitEnd;
+    }
+
+    @Override
+    public Long getEventId() {
+        return this.id;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.visitStart;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return this.visitEnd;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerMember.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerMember.java
@@ -22,6 +22,15 @@ public class SchedulerMember extends BaseTimeEntity {
     @JoinColumn(name = "userId")
     private User user;
 
+    protected SchedulerMember() {
+    }
+
+    // 필요한 인자를 받는 생성자
+    public SchedulerMember(Scheduler scheduler, User user) {
+        this.scheduler = scheduler;
+        this.user = user;
+    }
+
     public void setSchedulerMemberId(Long schedulerMemberId) {
         this.schedulerMemberId = schedulerMemberId;
     }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerMember.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerMember.java
@@ -1,0 +1,36 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.user.entity.User;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name = "SchedulerMembers")
+public class SchedulerMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long schedulerMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedulerId")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "userId")
+    private User user;
+
+    public void setSchedulerMemberId(Long schedulerMemberId) {
+        this.schedulerMemberId = schedulerMemberId;
+    }
+
+    public void setScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerRestaurant.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerRestaurant.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Restaurant;
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @Table(name = "SchedulerRestaurants")
-public class SchedulerRestaurant extends BaseTimeEntity {
+public class SchedulerRestaurant extends BaseTimeEntity implements Schedulable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,5 +38,20 @@ public class SchedulerRestaurant extends BaseTimeEntity {
         this.restaurant = restaurant;
         this.visitStart = visitStart;
         this.visitEnd = visitEnd;
+    }
+
+    @Override
+    public Long getEventId() {
+        return this.id;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.visitStart;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return this.visitEnd;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerRestaurant.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerRestaurant.java
@@ -1,0 +1,41 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Restaurant;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "SchedulerRestaurants")
+public class SchedulerRestaurant extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedulerId")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurantId")
+    private Restaurant restaurant;
+
+    @Column(nullable = false)
+    private LocalDateTime visitStart;
+
+    @Column(nullable = false)
+    private LocalDateTime visitEnd;
+
+    public SchedulerRestaurant(Scheduler scheduler, Restaurant restaurant, LocalDateTime visitStart, LocalDateTime visitEnd) {
+        this.scheduler = scheduler;
+        this.restaurant = restaurant;
+        this.visitStart = visitStart;
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerSeoulGoods.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerSeoulGoods.java
@@ -1,0 +1,41 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.entity;
+
+import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
+import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "SchedulerSeoulGoods")
+public class SchedulerSeoulGoods extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedulerId")
+    private Scheduler scheduler;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "goodsId")
+    private SeoulGoods seoulGoods;
+
+    @Column(nullable = false)
+    private LocalDateTime visitStart;
+
+    @Column(nullable = false)
+    private LocalDateTime visitEnd;
+
+    public SchedulerSeoulGoods(Scheduler scheduler, SeoulGoods seoulGoods, LocalDateTime visitStart, LocalDateTime visitEnd) {
+        this.scheduler = scheduler;
+        this.seoulGoods = seoulGoods;
+        this.visitStart = visitStart;
+        this.visitEnd = visitEnd;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerSeoulGoods.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/entity/SchedulerSeoulGoods.java
@@ -1,6 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.entity;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.SeoulGoods;
+import dnaaaaahtac.wooriforei.domain.scheduler.Schedulable;
 import dnaaaaahtac.wooriforei.global.auditing.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 @Table(name = "SchedulerSeoulGoods")
-public class SchedulerSeoulGoods extends BaseTimeEntity {
+public class SchedulerSeoulGoods extends BaseTimeEntity implements Schedulable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,5 +38,20 @@ public class SchedulerSeoulGoods extends BaseTimeEntity {
         this.seoulGoods = seoulGoods;
         this.visitStart = visitStart;
         this.visitEnd = visitEnd;
+    }
+
+    @Override
+    public Long getEventId() {
+        return this.id;
+    }
+
+    @Override
+    public LocalDateTime getStartTime() {
+        return this.visitStart;
+    }
+
+    @Override
+    public LocalDateTime getEndTime() {
+        return this.visitEnd;
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerActivityRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerActivityRepository.java
@@ -1,10 +1,14 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerActivity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerActivityRepository extends JpaRepository<SchedulerActivity, Long> {
 
+    List<SchedulerActivity> findByScheduler(Scheduler scheduler);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerActivityRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerActivityRepository.java
@@ -1,0 +1,10 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerActivityRepository extends JpaRepository<SchedulerActivity, Long> {
+
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerHotelRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerHotelRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerHotelRepository extends JpaRepository<SchedulerHotel, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerHotelRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerHotelRepository.java
@@ -1,9 +1,14 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerHotelRepository extends JpaRepository<SchedulerHotel, Long> {
+
+    List<SchedulerHotel> findByScheduler(Scheduler scheduler);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerInformationRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerInformationRepository.java
@@ -1,9 +1,15 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerInformation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerInformationRepository extends JpaRepository<SchedulerInformation, Long> {
+
+    List<SchedulerInformation> findByScheduler(Scheduler scheduler);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerInformationRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerInformationRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerInformation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerInformationRepository extends JpaRepository<SchedulerInformation, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerLandmarkRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerLandmarkRepository.java
@@ -1,9 +1,15 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerLandmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerLandmarkRepository extends JpaRepository<SchedulerLandmark, Long> {
+
+    List<SchedulerLandmark> findByScheduler(Scheduler scheduler);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerLandmarkRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerLandmarkRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerLandmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerLandmarkRepository extends JpaRepository<SchedulerLandmark, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
@@ -1,5 +1,6 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,7 @@ import java.util.List;
 public interface SchedulerMemberRepository extends JpaRepository<SchedulerMember, Long> {
 
     List<SchedulerMember> findByScheduler_SchedulerId(Long schedulerId);
+
+    List<SchedulerMember> findByScheduler(Scheduler scheduler);
 
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerMemberRepository extends JpaRepository<SchedulerMember, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
@@ -4,6 +4,11 @@ import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerMemberRepository extends JpaRepository<SchedulerMember, Long> {
+
+    List<SchedulerMember> findByScheduler_SchedulerId(Long schedulerId);
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerMemberRepository.java
@@ -14,4 +14,6 @@ public interface SchedulerMemberRepository extends JpaRepository<SchedulerMember
 
     List<SchedulerMember> findByScheduler(Scheduler scheduler);
 
+    void deleteAllByScheduler(Scheduler scheduler);
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerRepository extends JpaRepository<Scheduler, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerRestaurantRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerRestaurantRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerRestaurant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerRestaurantRepository extends JpaRepository<SchedulerRestaurant, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerRestaurantRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerRestaurantRepository.java
@@ -1,9 +1,15 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerRestaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerRestaurantRepository extends JpaRepository<SchedulerRestaurant, Long> {
+
+    List<SchedulerRestaurant> findByScheduler(Scheduler scheduler);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerSeoulGoodsRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerSeoulGoodsRepository.java
@@ -1,9 +1,15 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.repository;
 
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerSeoulGoods;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SchedulerSeoulGoodsRepository extends JpaRepository<SchedulerSeoulGoods, Long> {
+
+    List<SchedulerSeoulGoods> findByScheduler(Scheduler scheduler);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerSeoulGoodsRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/repository/SchedulerSeoulGoodsRepository.java
@@ -1,0 +1,9 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.repository;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerSeoulGoods;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulerSeoulGoodsRepository extends JpaRepository<SchedulerSeoulGoods, Long> {
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -1,9 +1,14 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.service;
 
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.ActivityRepository;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerActivityRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerRequestDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerActivity;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
+import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerActivityRepository;
 import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerMemberRepository;
 import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerRepository;
 import dnaaaaahtac.wooriforei.domain.user.dto.UserDetailResponseDTO;
@@ -25,6 +30,8 @@ public class SchedulerService {
 
     private final SchedulerRepository schedulerRepository;
     private final SchedulerMemberRepository schedulerMemberRepository;
+    private final ActivityRepository activityRepository;
+    private final SchedulerActivityRepository schedulerActivityRepository;
     private final UserRepository userRepository;
 
     @Transactional
@@ -178,4 +185,20 @@ public class SchedulerService {
         schedulerMemberRepository.deleteAllByScheduler(scheduler);
         schedulerRepository.delete(scheduler);
     }
+
+    @Transactional
+    public void addActivityToScheduler(Long schedulerId, SchedulerActivityRequestDTO activityDTO) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+
+        Activity activity = activityRepository.findById(activityDTO.getActivityId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ACTIVITY));
+
+        SchedulerActivity schedulerActivity = new SchedulerActivity(
+                scheduler, activity, activityDTO.getVisitStart(), activityDTO.getVisitEnd());
+        schedulerActivityRepository.save(schedulerActivity);
+
+        getSchedulerResponseDTO(schedulerId, scheduler);
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -1,13 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.service;
 
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
-import dnaaaaahtac.wooriforei.domain.openapi.entity.Landmark;
-import dnaaaaahtac.wooriforei.domain.openapi.repository.ActivityRepository;
-import dnaaaaahtac.wooriforei.domain.openapi.repository.HotelRepository;
-import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
-import dnaaaaahtac.wooriforei.domain.openapi.repository.LandmarkRepository;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.*;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.*;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.*;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.*;
 import dnaaaaahtac.wooriforei.domain.scheduler.repository.*;
@@ -39,6 +33,8 @@ public class SchedulerService {
     private final UserRepository userRepository;
     private final LandmarkRepository landmarkRepository;
     private final SchedulerLandmarkRepository schedulerLandmarkRepository;
+    private final RestaurantRepository restaurantRepository;
+    private final SchedulerRestaurantRepository schedulerRestaurantRepository;
 
     @Transactional
     public SchedulerResponseDTO createScheduler(SchedulerRequestDTO requestDTO) {
@@ -259,5 +255,22 @@ public class SchedulerService {
                 landmarkDTO.getVisitStart(), landmarkDTO.getVisitEnd());
 
         schedulerLandmarkRepository.save(schedulerLandmark);
+    }
+
+    @Transactional
+    public void addRestaurantToScheduler(Long schedulerId, SchedulerRestaurantRequestDTO restaurantDTO) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+
+        Restaurant restaurant = restaurantRepository.findById(restaurantDTO.getRestaurantId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_RESTAURANT));
+
+        SchedulerRestaurant schedulerRestaurant = new SchedulerRestaurant(
+                scheduler,
+                restaurant,
+                restaurantDTO.getVisitStart(),
+                restaurantDTO.getVisitEnd());
+
+        schedulerRestaurantRepository.save(schedulerRestaurant);
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -76,6 +76,7 @@ public class SchedulerService {
         return getSchedulerResponseDTO(savedScheduler, memberDetails);
     }
 
+
     @Transactional
     public SchedulerResponseDTO getSchedulerById(Long schedulerId) {
         Scheduler scheduler = schedulerRepository.findById(schedulerId)
@@ -90,18 +91,118 @@ public class SchedulerService {
                         member.getUser().getEmail()))
                 .collect(Collectors.toList());
 
+        List<SchedulerResponseDTO.OpenAPIDetailsDTO> openAPIs = collectOpenAPIDetails(scheduler);
+
+        return getSchedulerResponseDTO(scheduler, memberDetails, openAPIs);
+    }
+
+    private List<SchedulerResponseDTO.OpenAPIDetailsDTO> collectOpenAPIDetails(Scheduler scheduler) {
         List<SchedulerResponseDTO.OpenAPIDetailsDTO> openAPIs = new ArrayList<>();
 
+        // Activities
         List<SchedulerActivity> activities = schedulerActivityRepository.findByScheduler(scheduler);
-        for (SchedulerActivity activity : activities) {
-            SchedulerResponseDTO.OpenAPIDetailsDTO apiDetails = new SchedulerResponseDTO.OpenAPIDetailsDTO();
-            apiDetails.setId(activity.getActivity().getActivityId());
-            apiDetails.setName(activity.getActivity().getSvcnm());
-            apiDetails.setVisitStart(activity.getVisitStart());
-            apiDetails.setVisitEnd(activity.getVisitEnd());
-            apiDetails.setType("activity");
-            openAPIs.add(apiDetails);
-        }
+        openAPIs.addAll(activities.stream()
+                .map(this::convertActivityToOpenAPIDetails)
+                .collect(Collectors.toList()));
+
+        // Hotels
+        List<SchedulerHotel> hotels = schedulerHotelRepository.findByScheduler(scheduler);
+        openAPIs.addAll(hotels.stream()
+                .map(this::convertHotelToOpenAPIDetails)
+                .collect(Collectors.toList()));
+
+        // Information
+        List<SchedulerInformation> informations = schedulerInformationRepository.findByScheduler(scheduler);
+        openAPIs.addAll(informations.stream()
+                .map(this::convertInformationToOpenAPIDetails)
+                .collect(Collectors.toList()));
+
+        // Landmarks
+        List<SchedulerLandmark> landmarks = schedulerLandmarkRepository.findByScheduler(scheduler);
+        openAPIs.addAll(landmarks.stream()
+                .map(this::convertLandmarkToOpenAPIDetails)
+                .collect(Collectors.toList()));
+
+        // Restaurants
+        List<SchedulerRestaurant> restaurants = schedulerRestaurantRepository.findByScheduler(scheduler);
+        openAPIs.addAll(restaurants.stream()
+                .map(this::convertRestaurantToOpenAPIDetails)
+                .collect(Collectors.toList()));
+
+        // SeoulGoods
+        List<SchedulerSeoulGoods> seoulGoodsList = schedulerSeoulGoodsRepository.findByScheduler(scheduler);
+        openAPIs.addAll(seoulGoodsList.stream()
+                .map(this::convertSeoulGoodsToOpenAPIDetails)
+                .collect(Collectors.toList()));
+
+        return openAPIs;
+    }
+
+    private SchedulerResponseDTO.OpenAPIDetailsDTO convertActivityToOpenAPIDetails(SchedulerActivity activity) {
+        return new SchedulerResponseDTO.OpenAPIDetailsDTO(
+                activity.getActivity().getActivityId(),
+                activity.getActivity().getSvcnm(),
+                activity.getVisitStart(),
+                activity.getVisitEnd(),
+                "activity"
+        );
+    }
+
+    private SchedulerResponseDTO.OpenAPIDetailsDTO convertHotelToOpenAPIDetails(SchedulerHotel hotel) {
+        return new SchedulerResponseDTO.OpenAPIDetailsDTO(
+                hotel.getHotel().getHotelId(),
+                hotel.getHotel().getNameKor(),
+                hotel.getStayStart(),
+                hotel.getStayEnd(),
+                "hotel"
+        );
+    }
+
+    private SchedulerResponseDTO.OpenAPIDetailsDTO convertInformationToOpenAPIDetails(SchedulerInformation information) {
+        return new SchedulerResponseDTO.OpenAPIDetailsDTO(
+                information.getInformation().getInformationId(),
+                information.getInformation().getTrsmicnm(),
+                information.getVisitStart(),
+                information.getVisitEnd(),
+                "information"
+        );
+    }
+
+    private SchedulerResponseDTO.OpenAPIDetailsDTO convertLandmarkToOpenAPIDetails(SchedulerLandmark landmark) {
+        return new SchedulerResponseDTO.OpenAPIDetailsDTO(
+                landmark.getLandmark().getRandmarkId(),
+                landmark.getLandmark().getPostSj(),
+                landmark.getVisitStart(),
+                landmark.getVisitEnd(),
+                "landmark"
+        );
+    }
+
+    private SchedulerResponseDTO.OpenAPIDetailsDTO convertRestaurantToOpenAPIDetails(SchedulerRestaurant restaurant) {
+        return new SchedulerResponseDTO.OpenAPIDetailsDTO(
+                restaurant.getRestaurant().getRestaurantId(),
+                restaurant.getRestaurant().getPostSj(),
+                restaurant.getVisitStart(),
+                restaurant.getVisitEnd(),
+                "restaurant"
+        );
+    }
+
+    private SchedulerResponseDTO.OpenAPIDetailsDTO convertSeoulGoodsToOpenAPIDetails(SchedulerSeoulGoods seoulGoods) {
+        return new SchedulerResponseDTO.OpenAPIDetailsDTO(
+                seoulGoods.getSeoulGoods().getSeoulGoodsId(),
+                seoulGoods.getSeoulGoods().getNm(),
+                seoulGoods.getVisitStart(),
+                seoulGoods.getVisitEnd(),
+                "seoulGoods"
+        );
+    }
+
+
+    private SchedulerResponseDTO getSchedulerResponseDTO(
+            Scheduler scheduler,
+            List<UserDetailResponseDTO> memberDetails,
+            List<SchedulerResponseDTO.OpenAPIDetailsDTO> openAPIs) {
 
         SchedulerResponseDTO response = new SchedulerResponseDTO();
         response.setSchedulerId(scheduler.getSchedulerId());

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -3,9 +3,11 @@ package dnaaaaahtac.wooriforei.domain.scheduler.service;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Landmark;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.ActivityRepository;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.HotelRepository;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.LandmarkRepository;
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.*;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.*;
 import dnaaaaahtac.wooriforei.domain.scheduler.repository.*;
@@ -35,6 +37,8 @@ public class SchedulerService {
     private final SchedulerInformationRepository schedulerInformationRepository;
     private final HotelRepository hotelRepository;
     private final UserRepository userRepository;
+    private final LandmarkRepository landmarkRepository;
+    private final SchedulerLandmarkRepository schedulerLandmarkRepository;
 
     @Transactional
     public SchedulerResponseDTO createScheduler(SchedulerRequestDTO requestDTO) {
@@ -240,5 +244,20 @@ public class SchedulerService {
                 informationDTO.getVisitEnd());
 
         schedulerInformationRepository.save(schedulerInformation);
+    }
+
+    @Transactional
+    public void addLandmarkToScheduler(Long schedulerId, SchedulerLandmarkRequestDTO landmarkDTO) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+
+        Landmark landmark = landmarkRepository.findById(landmarkDTO.getLandmarkId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_LANDMARK));
+
+        SchedulerLandmark schedulerLandmark = new SchedulerLandmark(
+                scheduler, landmark,
+                landmarkDTO.getVisitStart(), landmarkDTO.getVisitEnd());
+
+        schedulerLandmarkRepository.save(schedulerLandmark);
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -2,20 +2,13 @@ package dnaaaaahtac.wooriforei.domain.scheduler.service;
 
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Activity;
 import dnaaaaahtac.wooriforei.domain.openapi.entity.Hotel;
+import dnaaaaahtac.wooriforei.domain.openapi.entity.Information;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.ActivityRepository;
 import dnaaaaahtac.wooriforei.domain.openapi.repository.HotelRepository;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerActivityRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerHotelRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
-import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerActivity;
-import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerHotel;
-import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
-import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerActivityRepository;
-import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerHotelRepository;
-import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerMemberRepository;
-import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerRepository;
+import dnaaaaahtac.wooriforei.domain.openapi.repository.InformationRepository;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.*;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.*;
+import dnaaaaahtac.wooriforei.domain.scheduler.repository.*;
 import dnaaaaahtac.wooriforei.domain.user.dto.UserDetailResponseDTO;
 import dnaaaaahtac.wooriforei.domain.user.entity.User;
 import dnaaaaahtac.wooriforei.domain.user.repository.UserRepository;
@@ -38,6 +31,8 @@ public class SchedulerService {
     private final ActivityRepository activityRepository;
     private final SchedulerActivityRepository schedulerActivityRepository;
     private final SchedulerHotelRepository schedulerHotelRepository;
+    private final InformationRepository informationRepository;
+    private final SchedulerInformationRepository schedulerInformationRepository;
     private final HotelRepository hotelRepository;
     private final UserRepository userRepository;
 
@@ -231,4 +226,19 @@ public class SchedulerService {
         schedulerHotelRepository.save(schedulerHotel);
     }
 
+    @Transactional
+    public void addInformationToScheduler(Long schedulerId, SchedulerInformationRequestDTO informationDTO) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+        Information information = informationRepository.findById(informationDTO.getInformationId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_INFORMATION));
+
+        SchedulerInformation schedulerInformation = new SchedulerInformation(
+                scheduler,
+                information,
+                informationDTO.getVisitStart(),
+                informationDTO.getVisitEnd());
+
+        schedulerInformationRepository.save(schedulerInformation);
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -35,6 +35,8 @@ public class SchedulerService {
     private final SchedulerLandmarkRepository schedulerLandmarkRepository;
     private final RestaurantRepository restaurantRepository;
     private final SchedulerRestaurantRepository schedulerRestaurantRepository;
+    private final SeoulGoodsRepository seoulGoodsRepository;
+    private final SchedulerSeoulGoodsRepository schedulerSeoulGoodsRepository;
 
     @Transactional
     public SchedulerResponseDTO createScheduler(SchedulerRequestDTO requestDTO) {
@@ -272,5 +274,22 @@ public class SchedulerService {
                 restaurantDTO.getVisitEnd());
 
         schedulerRestaurantRepository.save(schedulerRestaurant);
+    }
+
+    @Transactional
+    public void addSeoulGoodsToScheduler(Long schedulerId, SchedulerSeoulGoodsRequestDTO seoulGoodsDTO) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+
+        SeoulGoods seoulGoods = seoulGoodsRepository.findById(seoulGoodsDTO.getGoodsId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SEOUL_GOODS));
+
+        SchedulerSeoulGoods schedulerSeoulGoods = new SchedulerSeoulGoods(
+                scheduler,
+                seoulGoods,
+                seoulGoodsDTO.getVisitStart(),
+                seoulGoodsDTO.getVisitEnd());
+
+        schedulerSeoulGoodsRepository.save(schedulerSeoulGoods);
     }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -1,0 +1,73 @@
+package dnaaaaahtac.wooriforei.domain.scheduler.service;
+
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateRequestDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateResponseDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
+import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
+import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerMemberRepository;
+import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerRepository;
+import dnaaaaahtac.wooriforei.domain.user.dto.UserDetailResponseDTO;
+import dnaaaaahtac.wooriforei.domain.user.entity.User;
+import dnaaaaahtac.wooriforei.domain.user.repository.UserRepository;
+import dnaaaaahtac.wooriforei.global.exception.CustomException;
+import dnaaaaahtac.wooriforei.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SchedulerService {
+
+    private final SchedulerRepository schedulerRepository;
+    private final SchedulerMemberRepository schedulerMemberRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public SchedulerCreateResponseDTO createScheduler(SchedulerCreateRequestDTO requestDTO) {
+
+        if (requestDTO.getStartDate().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.INVALID_START_DATE);
+        }
+
+        if (requestDTO.getEndDate().isBefore(requestDTO.getStartDate())) {
+            throw new CustomException(ErrorCode.INVALID_END_DATE);
+        }
+
+        Scheduler scheduler = new Scheduler();
+        scheduler.setSchedulerName(requestDTO.getSchedulerName());
+        scheduler.setStartDate(requestDTO.getStartDate());
+        scheduler.setEndDate(requestDTO.getEndDate());
+
+        Scheduler savedScheduler = schedulerRepository.save(scheduler);
+
+        List<User> users = userRepository.findByEmailIn(requestDTO.getMemberEmails());
+        if (users.isEmpty()) {
+            throw new CustomException(ErrorCode.NOT_FOUND_USER_EXCEPTION);
+        }
+
+        users.forEach(user -> {
+            SchedulerMember member = new SchedulerMember();
+            member.setScheduler(savedScheduler);
+            member.setUser(user);
+            schedulerMemberRepository.save(member);
+        });
+
+        List<UserDetailResponseDTO> memberDetails = users.stream()
+                .map(user -> new UserDetailResponseDTO(user.getUserId(), user.getUsername(), user.getNickname(), user.getEmail()))
+                .collect(Collectors.toList());
+
+        SchedulerCreateResponseDTO response = new SchedulerCreateResponseDTO();
+        response.setSchedulerId(savedScheduler.getSchedulerId());
+        response.setSchedulerName(savedScheduler.getSchedulerName());
+        response.setStartDate(savedScheduler.getStartDate());
+        response.setEndDate(savedScheduler.getEndDate());
+        response.setMembers(memberDetails);
+
+        return response;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -1,7 +1,7 @@
 package dnaaaaahtac.wooriforei.domain.scheduler.service;
 
 import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateRequestDTO;
-import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerCreateResponseDTO;
+import dnaaaaahtac.wooriforei.domain.scheduler.dto.SchedulerResponseDTO;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.Scheduler;
 import dnaaaaahtac.wooriforei.domain.scheduler.entity.SchedulerMember;
 import dnaaaaahtac.wooriforei.domain.scheduler.repository.SchedulerMemberRepository;
@@ -28,7 +28,7 @@ public class SchedulerService {
     private final UserRepository userRepository;
 
     @Transactional
-    public SchedulerCreateResponseDTO createScheduler(SchedulerCreateRequestDTO requestDTO) {
+    public SchedulerResponseDTO createScheduler(SchedulerCreateRequestDTO requestDTO) {
 
         if (requestDTO.getStartDate().isBefore(LocalDateTime.now())) {
             throw new CustomException(ErrorCode.INVALID_START_DATE);
@@ -61,7 +61,7 @@ public class SchedulerService {
                 .map(user -> new UserDetailResponseDTO(user.getUserId(), user.getUsername(), user.getNickname(), user.getEmail()))
                 .collect(Collectors.toList());
 
-        SchedulerCreateResponseDTO response = new SchedulerCreateResponseDTO();
+        SchedulerResponseDTO response = new SchedulerResponseDTO();
         response.setSchedulerId(savedScheduler.getSchedulerId());
         response.setSchedulerName(savedScheduler.getSchedulerName());
         response.setStartDate(savedScheduler.getStartDate());
@@ -70,4 +70,29 @@ public class SchedulerService {
 
         return response;
     }
+
+    @Transactional
+    public SchedulerResponseDTO getSchedulerById(Long schedulerId) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+
+        List<SchedulerMember> schedulerMembers = schedulerMemberRepository.findByScheduler_SchedulerId(schedulerId);
+        List<UserDetailResponseDTO> memberDetails = schedulerMembers.stream()
+                .map(member -> new UserDetailResponseDTO(
+                        member.getUser().getUserId(),
+                        member.getUser().getUsername(),
+                        member.getUser().getNickname(),
+                        member.getUser().getEmail()))
+                .collect(Collectors.toList());
+
+        SchedulerResponseDTO response = new SchedulerResponseDTO();
+        response.setSchedulerId(scheduler.getSchedulerId());
+        response.setSchedulerName(scheduler.getSchedulerName());
+        response.setStartDate(scheduler.getStartDate());
+        response.setEndDate(scheduler.getEndDate());
+        response.setMembers(memberDetails);
+
+        return response;
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -170,4 +170,12 @@ public class SchedulerService {
         return response;
     }
 
+    @Transactional
+    public void deleteScheduler(Long schedulerId) {
+        Scheduler scheduler = schedulerRepository.findById(schedulerId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SCHEDULER));
+
+        schedulerMemberRepository.deleteAllByScheduler(scheduler);
+        schedulerRepository.delete(scheduler);
+    }
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -221,11 +221,9 @@ public class SchedulerService {
     @Transactional
     public List<SchedulerResponseDTO> getAllSchedulers() {
         List<Scheduler> schedulers = schedulerRepository.findAll();
-
         return schedulers.stream().map(scheduler -> {
-            List<SchedulerMember> schedulerMembers
-                    = schedulerMemberRepository.findByScheduler_SchedulerId(scheduler.getSchedulerId());
-            List<UserDetailResponseDTO> memberDetails = schedulerMembers.stream()
+            List<UserDetailResponseDTO> memberDetails = schedulerMemberRepository.findByScheduler_SchedulerId(scheduler.getSchedulerId())
+                    .stream()
                     .map(member -> new UserDetailResponseDTO(
                             member.getUser().getUserId(),
                             member.getUser().getUsername(),
@@ -233,8 +231,9 @@ public class SchedulerService {
                             member.getUser().getEmail()))
                     .collect(Collectors.toList());
 
-            return getSchedulerResponseDTO(scheduler, memberDetails);
+            List<SchedulerResponseDTO.OpenAPIDetailsDTO> openAPIs = collectOpenAPIDetails(scheduler);
 
+            return getSchedulerResponseDTO(scheduler, memberDetails, openAPIs);
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/scheduler/service/SchedulerService.java
@@ -61,14 +61,7 @@ public class SchedulerService {
                 .map(user -> new UserDetailResponseDTO(user.getUserId(), user.getUsername(), user.getNickname(), user.getEmail()))
                 .collect(Collectors.toList());
 
-        SchedulerResponseDTO response = new SchedulerResponseDTO();
-        response.setSchedulerId(savedScheduler.getSchedulerId());
-        response.setSchedulerName(savedScheduler.getSchedulerName());
-        response.setStartDate(savedScheduler.getStartDate());
-        response.setEndDate(savedScheduler.getEndDate());
-        response.setMembers(memberDetails);
-
-        return response;
+        return getSchedulerResponseDTO(savedScheduler, memberDetails);
     }
 
     @Transactional
@@ -85,11 +78,38 @@ public class SchedulerService {
                         member.getUser().getEmail()))
                 .collect(Collectors.toList());
 
+        return getSchedulerResponseDTO(scheduler, memberDetails);
+    }
+
+    @Transactional
+    public List<SchedulerResponseDTO> getAllSchedulers() {
+        List<Scheduler> schedulers = schedulerRepository.findAll();
+
+        return schedulers.stream().map(scheduler -> {
+            List<SchedulerMember> schedulerMembers
+                    = schedulerMemberRepository.findByScheduler_SchedulerId(scheduler.getSchedulerId());
+            List<UserDetailResponseDTO> memberDetails = schedulerMembers.stream()
+                    .map(member -> new UserDetailResponseDTO(
+                            member.getUser().getUserId(),
+                            member.getUser().getUsername(),
+                            member.getUser().getNickname(),
+                            member.getUser().getEmail()))
+                    .collect(Collectors.toList());
+
+            return getSchedulerResponseDTO(scheduler, memberDetails);
+
+        }).collect(Collectors.toList());
+    }
+
+
+    private SchedulerResponseDTO getSchedulerResponseDTO(Scheduler scheduler, List<UserDetailResponseDTO> memberDetails) {
         SchedulerResponseDTO response = new SchedulerResponseDTO();
         response.setSchedulerId(scheduler.getSchedulerId());
         response.setSchedulerName(scheduler.getSchedulerName());
         response.setStartDate(scheduler.getStartDate());
         response.setEndDate(scheduler.getEndDate());
+        response.setCreatedAt(scheduler.getCreatedAt());
+        response.setModifiedAt(scheduler.getModifiedAt());
         response.setMembers(memberDetails);
 
         return response;

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/user/dto/UserDetailResponseDTO.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/user/dto/UserDetailResponseDTO.java
@@ -1,0 +1,32 @@
+package dnaaaaahtac.wooriforei.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDetailResponseDTO {
+
+    private Long userId;
+    private String username;
+    private String nickname;
+    private String userEmail;
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+}

--- a/src/main/java/dnaaaaahtac/wooriforei/domain/user/repository/UserRepository.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ import dnaaaaahtac.wooriforei.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,6 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByEmail(String email);
+
+    List<User> findByEmailIn(List<String> emails);
 
     Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     NOT_FOUND_INFORMATION(404, "요청한 안내소를 찾을 수 없습니다."),
     NOT_FOUND_LANDMARK(404, "요청한 명소를 찾을 수 없습니다."),
     NOT_FOUND_RESTAURANT(404, "요청한 맛집을 찾을 수 없습니다."),
+    NOT_FOUND_SEOUL_GOODS(404, "요청한 기념품판매소를 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     NOT_FOUND_SCHEDULER(404, "요청한 스케줄러를 찾을 수 없습니다."),
     NOT_FOUND_ACTIVITY(404, "요청한 문화 체험을 찾을 수 없습니다."),
     NOT_FOUND_HOTEL(404, "요청한 호텔을 찾을 수 없습니다."),
+    NOT_FOUND_INFORMATION(404, "요청한 안내소를 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     NOT_FOUND_HOTEL(404, "요청한 호텔을 찾을 수 없습니다."),
     NOT_FOUND_INFORMATION(404, "요청한 안내소를 찾을 수 없습니다."),
     NOT_FOUND_LANDMARK(404, "요청한 명소를 찾을 수 없습니다."),
+    NOT_FOUND_RESTAURANT(404, "요청한 맛집을 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     // Scheduler
     INVALID_START_DATE(400, "시작일이 현재 시간 이전일 수 없습니다."),
     INVALID_END_DATE(400, "종료일이 시작일 이전일 수 없습니다."),
+    NOT_FOUND_SCHEDULER(404, "요청한 스케줄러를 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     INVALID_END_DATE(400, "종료일이 시작일 이전일 수 없습니다."),
     NOT_FOUND_SCHEDULER(404, "요청한 스케줄러를 찾을 수 없습니다."),
     NOT_FOUND_ACTIVITY(404, "요청한 문화 체험을 찾을 수 없습니다."),
+    NOT_FOUND_HOTEL(404, "요청한 호텔을 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     NOT_FOUND_ACTIVITY(404, "요청한 문화 체험을 찾을 수 없습니다."),
     NOT_FOUND_HOTEL(404, "요청한 호텔을 찾을 수 없습니다."),
     NOT_FOUND_INFORMATION(404, "요청한 안내소를 찾을 수 없습니다."),
+    NOT_FOUND_LANDMARK(404, "요청한 명소를 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     INVALID_START_DATE(400, "시작일이 현재 시간 이전일 수 없습니다."),
     INVALID_END_DATE(400, "종료일이 시작일 이전일 수 없습니다."),
     NOT_FOUND_SCHEDULER(404, "요청한 스케줄러를 찾을 수 없습니다."),
+    NOT_FOUND_ACTIVITY(404, "요청한 문화 체험을 찾을 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     NOT_FOUND_LANDMARK(404, "요청한 명소를 찾을 수 없습니다."),
     NOT_FOUND_RESTAURANT(404, "요청한 맛집을 찾을 수 없습니다."),
     NOT_FOUND_SEOUL_GOODS(404, "요청한 기념품판매소를 찾을 수 없습니다."),
+    INVALID_TIME_OVERLAP(409, "요청한 시간이 기존의 일정과 겹칩니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),

--- a/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
     // Faq
 
     // Scheduler
+    INVALID_START_DATE(400, "시작일이 현재 시간 이전일 수 없습니다."),
+    INVALID_END_DATE(400, "종료일이 시작일 이전일 수 없습니다."),
 
     //OpenAPI
     NOT_FOUND_DATA(404, "데이터가 존재하지 않습니다."),


### PR DESCRIPTION
OpenAPI 정보를 scheduler API에 통합하였습니다.

### 변경 사항
* SchedulerService 수정:
  * getAllSchedulers 및 getSchedulerById 메소드를 확장하여 관련 OpenAPI 엔티티들로부터의 상세 데이터를 포함하도록 했습니다.
  * 다양한 소스(문화체험, 호텔 등)로부터 데이터를 집계하고 OpenAPIDetailsDTO로 포맷하는 collectOpenAPIDetails 메소드를 구현했습니다.
* DTO 강화:
  * OpenAPI 엔티티들로부터의 확장 데이터를 수용하기 위해 SchedulerResponseDTO에 새로운 필드를 추가했습니다.
  * 각 관련 엔티티에 대한 상세 정보를 나타내는 OpenAPIDetailsDTO를 생성했습니다.
* scheduler CRUD
* 멤버 추가 기능

변경 사항을 검토하시고 피드백을 제공해 주세요.

