### PR TITLE
fix: cors 수정

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
@@ -15,6 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
@@ -37,6 +39,23 @@ public class WebSecurityConfig {
     }
 
     @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+
+        // TODO: 실제 배포 환경에서는 구체적인 도메인으로 제한해야 함
+        configuration.addAllowedOrigin("http://localhost:3000");
+
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.ignoringRequestMatchers("/api/auth/**", "/api/images/**", "/api/communities/**")) // 특정 경로에서만 CSRF 비활성화
@@ -54,7 +73,7 @@ public class WebSecurityConfig {
                 .addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class) // JWT 인증 필터 추가
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration corsConfiguration = new CorsConfiguration();
-                    corsConfiguration.setAllowedOrigins(List.of("http://localhost:8080", "https://www.wooriforei.info", "localhost:3000"));
+                    corsConfiguration.setAllowedOrigins(List.of("http://localhost:8080", "https://www.wooriforei.info", "http://localhost:3000"));
                     corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                     corsConfiguration.setAllowedHeaders(List.of("*"));
                     return corsConfiguration;


### PR DESCRIPTION
### 변경 사항 개요
* CORS 정책에 대한 업데이트가 이루어졌습니다. 
* 이 변경 사항은 로컬 개발 환경에서 프론트엔드가 백엔드 서버와 통신할 수 있도록 http://localhost:3000을 허용 목록에 추가했습니다.

### 배경
* 로컬에서 프론트엔드를 실행하고 백엔드 서버(https://www.wooriforei.info)와 통신할 때 CORS 정책 위반 문제가 발생했습니다.
* 프론트엔드와 백엔드 간의 통신이 필요하여, 이를 가능하게 하는 변경이 필요했습니다.

### 구체적 변경 내용
* WebSecurityConfig의 CORS 설정에 http://localhost:3000 오리진을 허용하도록 수정하였습니다.

### 테스트 방법
* (프론트 개발자가) 로컬에서 http://localhost:3000 주소로 프론트엔드를 실행합니다.
* 백엔드 서버에 대한 API 요청을 보내어, CORS 에러 없이 정상적으로 응답이 오는지 확인합니다.
* 다른 포트나 호스트에서 요청을 보낼 때 CORS 정책이 정상적으로 작동하여 요청을 차단하는지 확인합니다.

### 기대 결과
* http://localhost:3000에서 백엔드 서버로 API 요청 시, CORS 에러 없이 성공적으로 응답을 받아야 합니다.
* 다른 오리진에서 오는 요청들은 여전히 CORS 정책에 의해 차단되어야 합니다.

### 추가 정보
* 이 변경 사항은 개발 환경에만 영향을 미칩니다. 
* 실제 운영 환경에서의 CORS 정책은 별도로 구성되어 있습니다.
* 추후 프론트엔드가 배포되는 URL에 따라 추가적인 CORS 정책 업데이트가 필요할 수 있습니다.