### PR TITLE
fix: cors 수정

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
@@ -18,8 +18,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
-
 @Configuration
 @RequiredArgsConstructor
 public class WebSecurityConfig {
@@ -71,13 +69,9 @@ public class WebSecurityConfig {
                         .anyRequest().authenticated() // 나머지 경로는 인증 필요
                 )
                 .addFilterBefore(jwtAuthorizationFilter(), UsernamePasswordAuthenticationFilter.class) // JWT 인증 필터 추가
-                .cors(cors -> cors.configurationSource(request -> {
-                    CorsConfiguration corsConfiguration = new CorsConfiguration();
-                    corsConfiguration.setAllowedOrigins(List.of("http://localhost:8080", "https://www.wooriforei.info", "http://localhost:3000"));
-                    corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                    corsConfiguration.setAllowedHeaders(List.of("*"));
-                    return corsConfiguration;
-                }));
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // 여기서 람다 표현식 제거하고 빈을 참조하도록 변경
+        // .cors(cors -> cors.configurationSource(request -> { ... })) 부분을 삭제
+        ;
         return http.build();
     }
 }


### PR DESCRIPTION
### 변경 사항 개요
* 프로젝트의 CORS 설정을 단일 CorsConfigurationSource로 통합하여, 백엔드 서버의 CORS 정책이 일관되고 정확하게 적용되도록 변경하였습니다.

### 배경
* 로컬 및 배포된 프론트엔드 애플리케이션이 백엔드 API와 통신 시 CORS 오류에 직면함.
* 프론트엔드 팀에서 백엔드 서버에 요청 시 Access-Control-Allow-Origin 헤더가 없다는 문제를 보고함.
* CORS 설정이 WebSecurityConfig 안에서 중복으로 정의되어 있었으며, 이로 인해 설정이 제대로 적용되지 않을 가능성이 있음.

### 구체적 변경 내용
* WebSecurityConfig에서 중복된 CORS 설정을 제거하고, CorsConfigurationSource 빈을 사용하는 방식으로 통합하였습니다.
* 이는 SecurityFilterChain 안에서 .cors() 설정을 단순화하는 것을 포함합니다.
* 수정된 설정은 로컬 개발 환경(http://localhost:3000)의 프론트엔드 요청을 허용하도록 구성되어 있습니다.

### 테스트 방법
* 프론트 로컬(http://localhost:3000)에서 프론트엔드를 실행하고 백엔드 API로 요청을 보내어 통신이 정상적으로 이루어지는지 확인.
* 프록시 없이 직접 백엔드 서버로 요청을 보낼 때, Access-Control-Allow-Origin 헤더가 포함된 응답이 오는지 확인.
* 배포 환경에서도 테스트하여 프론트엔드가 백엔드와 통신할 수 있는지 검증.

### 기대 결과
* 이 변경을 통해 로컬 및 배포된 프론트엔드에서 백엔드 API로의 CORS 요청이 성공적으로 처리되어야 합니다.
* CORS 관련 이슈가 해결되며, 프론트엔드와 백엔드 간의 통신이 원활해야 합니다.