### PR TITLE
fix: cors 수정

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/domain/auth/controller/AwsController.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/domain/auth/controller/AwsController.java
@@ -1,6 +1,8 @@
 package dnaaaaahtac.wooriforei.domain.auth.controller;
 
 import dnaaaaahtac.wooriforei.global.common.CommonResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,4 +21,14 @@ public class AwsController {
 
         return ResponseEntity.ok().body(CommonResponse.of("hello wooriforei", null));
     }
+
+    @GetMapping("/test-cors")
+    public ResponseEntity<String> testCors() {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Access-Control-Allow-Origin", "http://localhost:3000");
+
+        return new ResponseEntity<>("CORS test response", headers, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
@@ -61,6 +61,7 @@ public class WebSecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(String.valueOf(PathRequest.toStaticResources().atCommonLocations())).permitAll()
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/test-cors").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/faqs/**").permitAll()
                         .requestMatchers("/api/openAPI/**").permitAll()


### PR DESCRIPTION
## Pull Request - CORS 테스트 엔드포인트 추가

### 변경 사항 개요

- CORS 문제를 진단하기 위해 백엔드에 테스트 엔드포인트를 추가했습니다.

### 배경

- 프론트엔드 애플리케이션이 백엔드 서버의 CORS 정책으로 인해 API 요청을 수행할 수 없는 문제가 지속적으로 보고되었습니다.
- 현재 구성된 CORS 정책이 정상적으로 작동하는지 확인하기 위해 진단을 위한 명시적인 테스트 엔드포인트를 설정했습니다.

### 구체적 변경 내용

- `WebSecurityConfig`에 새로운 `@GetMapping` 엔드포인트 `/test-cors`를 추가했습니다.
- 이 엔드포인트는 프론트엔드가 `http://localhost:3000`에서 발생한 요청에 대해 응답할 때 `Access-Control-Allow-Origin` 헤더를 명시적으로 포함하여 반환합니다.

### 테스트 방법

1. 프론트엔드에서 `http://localhost:3000`을 통해 `/test-cors` 엔드포인트로 GET 요청을 보냅니다.
2. 응답 헤더에 `Access-Control-Allow-Origin: http://localhost:3000`이 포함되어 있는지 확인합니다.
3. 다른 오리진에서 요청을 보낼 경우, 요청이 실패하는지 확인합니다.

### 기대 결과

- 이 테스트 엔드포인트를 통해 프론트엔드에서 정상적으로 요청을 보내고, `Access-Control-Allow-Origin` 헤더를 포함한 응답을 받을 수 있어야 합니다.
- 이는 CORS 정책이 예상대로 작동하고 있음을 확인하는 데 도움이 될 것입니다.

### 주의 사항

- 이 엔드포인트는 테스트 목적으로만 사용됩니다. 문제가 해결되면, 이 엔드포인트는 제거될 예정입니다.
- 실제 배포 환경에서 CORS 정책을 재검토하고, 필요한 경우 보다 안전한 설정으로 업데이트해야 합니다.