### PR TITLE
fix: cors 수정

### DIFF
--- a/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
+++ b/src/main/java/dnaaaaahtac/wooriforei/global/config/WebSecurityConfig.java
@@ -18,7 +18,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
+import java.util.Arrays;
 
 @Configuration
 @RequiredArgsConstructor
@@ -42,10 +42,7 @@ public class WebSecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-
-        // TODO: 실제 배포 환경에서는 구체적인 도메인으로 제한해야 함
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://www.wooriforei.info"));
-
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:3000", "https://www.wooriforei.info"));
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
 


### PR DESCRIPTION
## Pull Request: CORS 정책 수정

### 변경 사항

- `WebSecurityConfig` 클래스의 CORS 관련 설정을 업데이트하여, 로컬 개발 환경(`localhost:3000`)과 프로덕션 서버(`https://www.wooriforei.info`) 모두에서의 요청을 허용합니다.
- `CorsConfigurationSource` 메소드를 통해 허용된 출처 패턴을 명시적으로 정의합니다.

### 배경

프론트엔드에서 백엔드 서버로의 교차 출처 요청 처리에 있어 `Access-Control-Allow-Origin` 헤더가 응답에 포함되지 않아 발생한 CORS 에러를 해결하기 위한 변경입니다. 이 오류는 프론트엔드 애플리케이션의 개발 및 배포된 환경 모두에서 API 요청이 실패하는 문제로 이어졌습니다.

### 상세 변경 내용

- `corsConfigurationSource` 내에서 `setAllowedOrigins`를 `setAllowedOriginPatterns`로 변경하여 정규 표현식을 사용하고, 배열에 두 개의 오리진 패턴을 추가하였습니다.
- `securityFilterChain` 메소드 내의 `.cors(cors -> cors.configurationSource(corsConfigurationSource()))` 설정을 통해 글로벌 CORS 정책을 적용하였습니다.

### 테스트 방법

- 로컬 개발 서버에서 프론트엔드 애플리케이션을 실행하고, 백엔드 서버로 요청을 보낸 후 정상적으로 응답을 받는지 확인합니다.
- 변경 사항을 프로덕션 서버에 배포한 후, 배포된 프론트엔드 애플리케이션에서 백엔드 서버로의 요청이 성공하는지 확인합니다.

### 기대 효과

이 변경으로 다음과 같은 기대 효과가 있습니다:

- 교차 출처 요청에 대한 문제가 해결되어, 프론트엔드 애플리케이션의 개발 및 운영 환경에서 원활한 API 통신이 가능해집니다.
- 브라우저의 보안 정책에 따라 다른 도메인/포트 간의 요청이 제대로 처리되어, 개발 효율성과 사용자 경험이 향상됩니다.